### PR TITLE
fix: ensure save directory exists before writing mapImage.png

### DIFF
--- a/src/mapimage/mapImageGenerator.py
+++ b/src/mapimage/mapImageGenerator.py
@@ -23,6 +23,8 @@ class MapImageGenerator:
         self.roomImagesDirectoryPath = self.config.pathToSaveDirectory + "/roompngs"
         self.mapImagePath = self.config.pathToSaveDirectory + "/mapImage.png"
 
+        os.makedirs(self.config.pathToSaveDirectory, exist_ok=True)
+
         if self.mapImageExists():
             self.mapImage = self.getExistingMapImage()
         else:


### PR DESCRIPTION
## Summary
- `MapImageUpdater` writes `mapImage.png` from a background thread on a cooldown timer, racing ahead of the world-save flow that normally creates `saves/<savefile>/`.
- PIL's `Image.save()` does not create parent directories, so on a fresh world (no `saves/defaultsavefile/` yet) the updater crashes with `FileNotFoundError: [Errno 2] No such file or directory: 'saves/defaultsavefile/mapImage.png'`.
- Guarantees the save directory exists from `MapImageGenerator.__init__`, mirroring the pattern in `src/codex/codexJsonReaderWriter.py:27-28`.

## Test plan
- [ ] Delete `saves/defaultsavefile/` (or run on a fresh checkout), launch the game, wait past the map-update cooldown — no `error updating map image` traceback in logs
- [ ] `pytest tests/` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_