### PR TITLE
feat: add lightweight goal/progression system (#375)

### DIFF
--- a/schemas/goals.json
+++ b/schemas/goals.json
@@ -1,0 +1,12 @@
+{
+    "type": "object",
+    "properties": {
+        "completedGoals": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    },
+    "required": ["completedGoals"]
+}

--- a/src/goals/goal.py
+++ b/src/goals/goal.py
@@ -1,0 +1,52 @@
+# @author Daniel McCoy Stephenson
+
+
+class Goal:
+    """A single progression goal.
+
+    A goal measures progress with a function that receives a GoalContext and
+    returns an integer (how far the player has gotten). The goal is complete
+    once that value reaches the target.
+    """
+
+    def __init__(self, identifier, description, target, progressFunction):
+        self.identifier = identifier
+        self.description = description
+        self.target = target
+        self.progressFunction = progressFunction
+        self.completed = False
+
+    def getIdentifier(self):
+        return self.identifier
+
+    def getDescription(self):
+        return self.description
+
+    def getTarget(self):
+        return self.target
+
+    def isCompleted(self):
+        return self.completed
+
+    def setCompleted(self, completed):
+        self.completed = completed
+
+    def getProgress(self, context):
+        """Return current progress toward the goal, clamped to the target."""
+        progress = self.progressFunction(context)
+        if progress > self.target:
+            return self.target
+        return progress
+
+    def evaluate(self, context):
+        """Recompute completion from the context.
+
+        Returns True only when this call transitions the goal from incomplete
+        to complete, so callers can react to fresh completions (e.g. a toast).
+        """
+        if self.completed:
+            return False
+        if self.progressFunction(context) >= self.target:
+            self.completed = True
+            return True
+        return False

--- a/src/goals/goalContext.py
+++ b/src/goals/goalContext.py
@@ -1,0 +1,15 @@
+# @author Daniel McCoy Stephenson
+
+
+class GoalContext:
+    """A snapshot of the game state that goals are evaluated against.
+
+    Bundling the relevant systems here keeps individual goal conditions
+    decoupled from how those systems are wired together.
+    """
+
+    def __init__(self, stats, codex, dayNightCycle, tickCounter):
+        self.stats = stats
+        self.codex = codex
+        self.dayNightCycle = dayNightCycle
+        self.tickCounter = tickCounter

--- a/src/goals/goalRegistry.py
+++ b/src/goals/goalRegistry.py
@@ -1,0 +1,46 @@
+# @author Daniel McCoy Stephenson
+from goals.goal import Goal
+
+
+class GoalRegistry:
+    """Defines the default set of progression goals.
+
+    Goals rely only on state Roam already tracks (explored rooms, food eaten,
+    Codex discoveries, the day/night cycle), so no new instrumentation is
+    required for this initial set.
+    """
+
+    def getGoals(self):
+        return [
+            Goal(
+                "explore_5_rooms",
+                "Explore 5 rooms",
+                5,
+                lambda context: context.stats.getRoomsExplored(),
+            ),
+            Goal(
+                "eat_10_food",
+                "Eat 10 food",
+                10,
+                lambda context: context.stats.getFoodEaten(),
+            ),
+            Goal(
+                "discover_3_entities",
+                "Discover 3 entities in the Codex",
+                3,
+                lambda context: len(context.codex.getDiscoveredEntities()),
+            ),
+            Goal(
+                "experience_nightfall",
+                "Experience nightfall",
+                1,
+                lambda context: (
+                    1
+                    if context.dayNightCycle.getPhase(
+                        context.tickCounter.getTick()
+                    )
+                    == "night"
+                    else 0
+                ),
+            ),
+        ]

--- a/src/goals/goalRegistry.py
+++ b/src/goals/goalRegistry.py
@@ -1,17 +1,36 @@
 # @author Daniel McCoy Stephenson
 from goals.goal import Goal
+from codex.codex import ALL_LIVING_ENTITY_TYPES
+
+
+def _discovered(context, name):
+    return 1 if name in context.codex.getDiscoveredEntities() else 0
+
+
+def _discoveredCreatureCount(context):
+    discovered = context.codex.getDiscoveredEntities()
+    return sum(1 for name in ALL_LIVING_ENTITY_TYPES if name in discovered)
+
+
+def _isPhase(context, phase):
+    return (
+        1
+        if context.dayNightCycle.getPhase(context.tickCounter.getTick()) == phase
+        else 0
+    )
 
 
 class GoalRegistry:
     """Defines the default set of progression goals.
 
     Goals rely only on state Roam already tracks (explored rooms, food eaten,
-    Codex discoveries, the day/night cycle), so no new instrumentation is
-    required for this initial set.
+    score, Codex discoveries, the day/night cycle), so no new instrumentation
+    is required.
     """
 
     def getGoals(self):
         return [
+            # Exploration
             Goal(
                 "explore_5_rooms",
                 "Explore 5 rooms",
@@ -19,28 +38,73 @@ class GoalRegistry:
                 lambda context: context.stats.getRoomsExplored(),
             ),
             Goal(
+                "explore_25_rooms",
+                "Explore 25 rooms",
+                25,
+                lambda context: context.stats.getRoomsExplored(),
+            ),
+            Goal(
+                "explore_100_rooms",
+                "Explore 100 rooms",
+                100,
+                lambda context: context.stats.getRoomsExplored(),
+            ),
+            # Food / survival
+            Goal(
                 "eat_10_food",
                 "Eat 10 food",
                 10,
                 lambda context: context.stats.getFoodEaten(),
             ),
             Goal(
-                "discover_3_entities",
-                "Discover 3 entities in the Codex",
-                3,
-                lambda context: len(context.codex.getDiscoveredEntities()),
+                "eat_50_food",
+                "Eat 50 food",
+                50,
+                lambda context: context.stats.getFoodEaten(),
             ),
+            # Codex discovery
+            Goal(
+                "discover_chicken",
+                "Discover a Chicken",
+                1,
+                lambda context: _discovered(context, "Chicken"),
+            ),
+            Goal(
+                "discover_bear",
+                "Discover a Bear",
+                1,
+                lambda context: _discovered(context, "Bear"),
+            ),
+            Goal(
+                "discover_all_creatures",
+                "Discover every creature",
+                len(ALL_LIVING_ENTITY_TYPES),
+                _discoveredCreatureCount,
+            ),
+            # Day / night cycle
             Goal(
                 "experience_nightfall",
                 "Experience nightfall",
                 1,
-                lambda context: (
-                    1
-                    if context.dayNightCycle.getPhase(
-                        context.tickCounter.getTick()
-                    )
-                    == "night"
-                    else 0
-                ),
+                lambda context: _isPhase(context, "night"),
+            ),
+            Goal(
+                "witness_dawn",
+                "Witness the dawn",
+                1,
+                lambda context: _isPhase(context, "dawn"),
+            ),
+            # Score milestones
+            Goal(
+                "reach_score_25",
+                "Reach a score of 25",
+                25,
+                lambda context: context.stats.getScore(),
+            ),
+            Goal(
+                "reach_score_100",
+                "Reach a score of 100",
+                100,
+                lambda context: context.stats.getScore(),
             ),
         ]

--- a/src/goals/goals.py
+++ b/src/goals/goals.py
@@ -1,0 +1,69 @@
+# @author Daniel McCoy Stephenson
+from appContainer import component
+
+from stats.stats import Stats
+from codex.codex import Codex
+from world.dayNightCycle import DayNightCycle
+from world.tickCounter import TickCounter
+from goals.goalRegistry import GoalRegistry
+from goals.goalContext import GoalContext
+from gameLogging.logger import getLogger
+
+_logger = getLogger(__name__)
+
+
+@component
+class Goals:
+    """Tracks the player's progression goals and their completion state."""
+
+    def __init__(
+        self,
+        stats: Stats,
+        codex: Codex,
+        dayNightCycle: DayNightCycle,
+        tickCounter: TickCounter,
+    ):
+        self.stats = stats
+        self.codex = codex
+        self.dayNightCycle = dayNightCycle
+        self.tickCounter = tickCounter
+        self.goals = GoalRegistry().getGoals()
+
+    def _buildContext(self):
+        return GoalContext(
+            self.stats, self.codex, self.dayNightCycle, self.tickCounter
+        )
+
+    def evaluate(self):
+        """Re-evaluate every goal.
+
+        Returns the goals that were newly completed by this call so the caller
+        can surface them (e.g. a status message).
+        """
+        context = self._buildContext()
+        newlyCompleted = []
+        for goal in self.goals:
+            if goal.evaluate(context):
+                newlyCompleted.append(goal)
+                _logger.info("goal completed", goal=goal.getIdentifier())
+        return newlyCompleted
+
+    def getGoals(self):
+        return self.goals
+
+    def getProgress(self, goal):
+        return goal.getProgress(self._buildContext())
+
+    def getCompletedCount(self):
+        return sum(1 for goal in self.goals if goal.isCompleted())
+
+    def getTotalCount(self):
+        return len(self.goals)
+
+    def getCompletedIdentifiers(self):
+        return [goal.getIdentifier() for goal in self.goals if goal.isCompleted()]
+
+    def setCompletedIdentifiers(self, identifiers):
+        completed = set(identifiers)
+        for goal in self.goals:
+            goal.setCompleted(goal.getIdentifier() in completed)

--- a/src/goals/goalsJsonReaderWriter.py
+++ b/src/goals/goalsJsonReaderWriter.py
@@ -1,0 +1,54 @@
+# @author Daniel McCoy Stephenson
+from appContainer import component
+
+import json
+import os
+import jsonschema
+
+from config.config import Config
+from gameLogging.logger import getLogger
+
+_logger = getLogger(__name__)
+
+
+@component
+class GoalsJsonReaderWriter:
+    def __init__(self, config: Config):
+        self.config = config
+
+    def save(self, completedIdentifiers):
+        data = {"completedGoals": list(completedIdentifiers)}
+
+        with open("schemas/goals.json") as f:
+            schema = json.load(f)
+        try:
+            jsonschema.validate(data, schema)
+        except jsonschema.exceptions.ValidationError as e:
+            _logger.error("goals validation error on save", error=str(e))
+
+        if not os.path.exists(self.config.pathToSaveDirectory):
+            os.makedirs(self.config.pathToSaveDirectory)
+
+        path = self.config.pathToSaveDirectory + "/goals.json"
+        with open(path, "w") as f:
+            json.dump(data, f, indent=4)
+        _logger.info("goals saved", path=path)
+
+    def load(self):
+        path = self.config.pathToSaveDirectory + "/goals.json"
+        if not os.path.exists(path):
+            return []
+
+        try:
+            with open(path) as f:
+                data = json.load(f)
+
+            with open("schemas/goals.json") as f:
+                schema = json.load(f)
+            jsonschema.validate(data, schema)
+        except (json.JSONDecodeError, jsonschema.exceptions.ValidationError) as e:
+            _logger.error("goals validation error on load", error=str(e), path=path)
+            return []
+
+        _logger.info("goals loaded", path=path)
+        return data["completedGoals"]

--- a/src/screen/statsScreen.py
+++ b/src/screen/statsScreen.py
@@ -5,6 +5,7 @@ from lib.graphik.src.graphik import Graphik
 from screen.screenType import ScreenType
 from screen.screenshotHelper import takeScreenshot
 from stats.stats import Stats
+from goals.goals import Goals
 from ui.status import Status
 import pygame
 
@@ -19,12 +20,14 @@ class StatsScreen:
         status: Status,
         stats: Stats,
         keyBindings: KeyBindings,
+        goals: Goals,
     ):
         self.graphik = graphik
         self.config = config
         self.status = status
         self.stats = stats
         self.keyBindings = keyBindings
+        self.goals = goals
         self.nextScreen = ScreenType.OPTIONS_SCREEN
         self.changeScreen = False
 
@@ -69,6 +72,37 @@ class StatsScreen:
 
         text = "Deaths: " + str(self.stats.getNumberOfDeaths())
         self.graphik.drawText(text, xpos, ypos + lineSpacing * 3, 30, (255, 255, 255))
+
+        self.drawGoals(xpos, ypos + lineSpacing * 3 + 60)
+
+    def drawGoals(self, xpos, startY):
+        header = (
+            "Goals ("
+            + str(self.goals.getCompletedCount())
+            + "/"
+            + str(self.goals.getTotalCount())
+            + ")"
+        )
+        self.graphik.drawText(header, xpos, startY, 26, (255, 255, 255))
+
+        for i, goal in enumerate(self.goals.getGoals()):
+            progress = self.goals.getProgress(goal)
+            if goal.isCompleted():
+                marker = "[X] "
+                color = (120, 220, 120)
+            else:
+                marker = "[ ] "
+                color = (200, 200, 200)
+            line = (
+                marker
+                + goal.getDescription()
+                + " ("
+                + str(progress)
+                + "/"
+                + str(goal.getTarget())
+                + ")"
+            )
+            self.graphik.drawText(line, xpos, startY + 32 + i * 28, 20, color)
 
     def drawBackButton(self):
         x, y = self.graphik.getGameDisplay().get_size()

--- a/src/screen/statsScreen.py
+++ b/src/screen/statsScreen.py
@@ -76,14 +76,14 @@ class StatsScreen:
         self.drawGoals(xpos, ypos + lineSpacing * 3 + 60)
 
     def drawGoals(self, xpos, startY):
-        header = (
-            "Goals ("
-            + str(self.goals.getCompletedCount())
-            + "/"
-            + str(self.goals.getTotalCount())
-            + ")"
-        )
-        self.graphik.drawText(header, xpos, startY, 26, (255, 255, 255))
+        completed = self.goals.getCompletedCount()
+        total = self.goals.getTotalCount()
+        allComplete = total > 0 and completed == total
+        header = "Goals (" + str(completed) + "/" + str(total) + ")"
+        if allComplete:
+            header += " - All complete!"
+        headerColor = (120, 220, 120) if allComplete else (255, 255, 255)
+        self.graphik.drawText(header, xpos, startY, 26, headerColor)
 
         goals = self.goals.getGoals()
         columnCount = 2

--- a/src/screen/statsScreen.py
+++ b/src/screen/statsScreen.py
@@ -85,7 +85,15 @@ class StatsScreen:
         )
         self.graphik.drawText(header, xpos, startY, 26, (255, 255, 255))
 
-        for i, goal in enumerate(self.goals.getGoals()):
+        goals = self.goals.getGoals()
+        columnCount = 2
+        perColumn = (len(goals) + columnCount - 1) // columnCount
+        displayWidth = self.graphik.getGameDisplay().get_size()[0]
+        columnX = [displayWidth / 4, displayWidth * 3 / 4]
+        rowSpacing = 26
+        rowsStartY = startY + 34
+
+        for i, goal in enumerate(goals):
             progress = self.goals.getProgress(goal)
             if goal.isCompleted():
                 marker = "[X] "
@@ -102,7 +110,11 @@ class StatsScreen:
                 + str(goal.getTarget())
                 + ")"
             )
-            self.graphik.drawText(line, xpos, startY + 32 + i * 28, 20, color)
+            column = i // perColumn
+            row = i % perColumn
+            self.graphik.drawText(
+                line, columnX[column], rowsStartY + row * rowSpacing, 18, color
+            )
 
     def drawBackButton(self):
         x, y = self.graphik.getGameDisplay().get_size()

--- a/src/screen/statsScreen.py
+++ b/src/screen/statsScreen.py
@@ -101,15 +101,9 @@ class StatsScreen:
             else:
                 marker = "[ ] "
                 color = (200, 200, 200)
-            line = (
-                marker
-                + goal.getDescription()
-                + " ("
-                + str(progress)
-                + "/"
-                + str(goal.getTarget())
-                + ")"
-            )
+            line = marker + goal.getDescription()
+            if goal.getTarget() > 1:
+                line += " (" + str(progress) + "/" + str(goal.getTarget()) + ")"
             column = i // perColumn
             row = i % perColumn
             self.graphik.drawText(

--- a/src/screen/worldScreen.py
+++ b/src/screen/worldScreen.py
@@ -24,6 +24,8 @@ from screen.screenshotHelper import takeScreenshot
 from screen.worldScreenPersistence import WorldScreenPersistence
 from stats.stats import Stats
 from ui.energyBar import EnergyBar
+from goals.goals import Goals
+from goals.goalsJsonReaderWriter import GoalsJsonReaderWriter
 from lib.graphik.src.graphik import Graphik
 from entity.grass import Grass
 from lib.pyenvlib.grid import Grid
@@ -90,6 +92,8 @@ class WorldScreen:
         self.hudDragManager = self.container.resolve(HudDragManager)
         self.codex = self.container.resolve(Codex)
         self.dayNightCycle = self.container.resolve(DayNightCycle)
+        self.goals = self.container.resolve(Goals)
+        self.goalsJsonReaderWriter = self.container.resolve(GoalsJsonReaderWriter)
         self.deathRespawnTicksRemaining = 0
         self.pausedByFocusLoss = False
         self._dayNightOverlay = None
@@ -135,6 +139,9 @@ class WorldScreen:
 
         if os.path.exists(self.config.pathToSaveDirectory + "/tick.json"):
             self.tickCounter.load()
+
+        if os.path.exists(self.config.pathToSaveDirectory + "/goals.json"):
+            self.goals.setCompletedIdentifiers(self.goalsJsonReaderWriter.load())
 
         if os.path.exists(self.config.pathToSaveDirectory + "/playerInventory.json"):
             self.loadPlayerInventoryFromFile()
@@ -1990,7 +1997,14 @@ class WorldScreen:
 
         self.currentRoom.reproduceLivingEntities(self.tickCounter.getTick())
 
+    def _updateGoals(self):
+        # Re-evaluate goals; announce and persist any fresh completions.
+        for goal in self.goals.evaluate():
+            self.status.set("Goal complete: " + goal.getDescription())
+            self.goalsJsonReaderWriter.save(self.goals.getCompletedIdentifiers())
+
     def _updateGameState(self):
+        self._updateGoals()
         if self.pausedByFocusLoss:
             self.draw()
             pygame.display.update()

--- a/src/screen/worldScreen.py
+++ b/src/screen/worldScreen.py
@@ -1999,9 +1999,14 @@ class WorldScreen:
 
     def _updateGoals(self):
         # Re-evaluate goals; announce and persist any fresh completions.
-        for goal in self.goals.evaluate():
-            self.status.set("Goal complete: " + goal.getDescription())
-            self.goalsJsonReaderWriter.save(self.goals.getCompletedIdentifiers())
+        newlyCompleted = self.goals.evaluate()
+        if not newlyCompleted:
+            return
+        if len(newlyCompleted) == 1:
+            self.status.set("Goal complete: " + newlyCompleted[0].getDescription())
+        else:
+            self.status.set(str(len(newlyCompleted)) + " goals complete!")
+        self.goalsJsonReaderWriter.save(self.goals.getCompletedIdentifiers())
 
     def _updateGameState(self):
         self._updateGoals()

--- a/tests/goals/test_goals.py
+++ b/tests/goals/test_goals.py
@@ -7,15 +7,19 @@ from goals.goalsJsonReaderWriter import GoalsJsonReaderWriter
 
 
 class FakeStats:
-    def __init__(self, rooms=0, food=0):
+    def __init__(self, rooms=0, food=0, score=0):
         self._rooms = rooms
         self._food = food
+        self._score = score
 
     def getRoomsExplored(self):
         return self._rooms
 
     def getFoodEaten(self):
         return self._food
+
+    def getScore(self):
+        return self._score
 
 
 class FakeCodex:
@@ -47,18 +51,18 @@ class FakeConfig:
         self.pathToSaveDirectory = path
 
 
-def makeContext(rooms=0, food=0, discovered=None, phase="day"):
+def makeContext(rooms=0, food=0, score=0, discovered=None, phase="day"):
     return GoalContext(
-        FakeStats(rooms, food),
+        FakeStats(rooms, food, score),
         FakeCodex(discovered),
         FakeDayNightCycle(phase),
         FakeTickCounter(),
     )
 
 
-def makeGoals(rooms=0, food=0, discovered=None, phase="day"):
+def makeGoals(rooms=0, food=0, score=0, discovered=None, phase="day"):
     return Goals(
-        FakeStats(rooms, food),
+        FakeStats(rooms, food, score),
         FakeCodex(discovered),
         FakeDayNightCycle(phase),
         FakeTickCounter(),
@@ -91,9 +95,18 @@ def test_progress_is_clamped_to_target():
 def test_registry_provides_default_goals():
     ids = [g.getIdentifier() for g in GoalRegistry().getGoals()]
     assert "explore_5_rooms" in ids
-    assert "eat_10_food" in ids
-    assert "discover_3_entities" in ids
+    assert "explore_100_rooms" in ids
+    assert "eat_50_food" in ids
+    assert "discover_bear" in ids
+    assert "discover_all_creatures" in ids
     assert "experience_nightfall" in ids
+    assert "witness_dawn" in ids
+    assert "reach_score_25" in ids
+
+
+def test_registry_goal_ids_are_unique():
+    ids = [g.getIdentifier() for g in GoalRegistry().getGoals()]
+    assert len(ids) == len(set(ids))
 
 
 def test_evaluate_reports_newly_completed_once():
@@ -109,10 +122,26 @@ def test_nightfall_goal_completes_at_night():
     assert "experience_nightfall" in ids
 
 
-def test_discovery_goal_uses_codex_count():
-    goals = makeGoals(discovered=["Bear", "Chicken", "Apple"])
+def test_specific_creature_discovery_goal_completes():
+    goals = makeGoals(discovered=["Chicken"])
     ids = [g.getIdentifier() for g in goals.evaluate()]
-    assert "discover_3_entities" in ids
+    assert "discover_chicken" in ids
+    assert "discover_bear" not in ids
+    assert "discover_all_creatures" not in ids
+
+
+def test_discover_all_creatures_completes_when_all_found():
+    goals = makeGoals(discovered=["Bear", "Chicken"])
+    ids = [g.getIdentifier() for g in goals.evaluate()]
+    assert "discover_all_creatures" in ids
+
+
+def test_score_and_dawn_goals_complete():
+    goals = makeGoals(score=100, phase="dawn")
+    ids = [g.getIdentifier() for g in goals.evaluate()]
+    assert "reach_score_25" in ids
+    assert "reach_score_100" in ids
+    assert "witness_dawn" in ids
 
 
 def test_completed_count_and_total():

--- a/tests/goals/test_goals.py
+++ b/tests/goals/test_goals.py
@@ -1,0 +1,148 @@
+# @author Daniel McCoy Stephenson
+from goals.goal import Goal
+from goals.goalContext import GoalContext
+from goals.goalRegistry import GoalRegistry
+from goals.goals import Goals
+from goals.goalsJsonReaderWriter import GoalsJsonReaderWriter
+
+
+class FakeStats:
+    def __init__(self, rooms=0, food=0):
+        self._rooms = rooms
+        self._food = food
+
+    def getRoomsExplored(self):
+        return self._rooms
+
+    def getFoodEaten(self):
+        return self._food
+
+
+class FakeCodex:
+    def __init__(self, discovered=None):
+        self._discovered = discovered or []
+
+    def getDiscoveredEntities(self):
+        return self._discovered
+
+
+class FakeDayNightCycle:
+    def __init__(self, phase="day"):
+        self._phase = phase
+
+    def getPhase(self, tick):
+        return self._phase
+
+
+class FakeTickCounter:
+    def __init__(self, tick=0):
+        self._tick = tick
+
+    def getTick(self):
+        return self._tick
+
+
+class FakeConfig:
+    def __init__(self, path):
+        self.pathToSaveDirectory = path
+
+
+def makeContext(rooms=0, food=0, discovered=None, phase="day"):
+    return GoalContext(
+        FakeStats(rooms, food),
+        FakeCodex(discovered),
+        FakeDayNightCycle(phase),
+        FakeTickCounter(),
+    )
+
+
+def makeGoals(rooms=0, food=0, discovered=None, phase="day"):
+    return Goals(
+        FakeStats(rooms, food),
+        FakeCodex(discovered),
+        FakeDayNightCycle(phase),
+        FakeTickCounter(),
+    )
+
+
+def test_goal_completes_when_target_reached():
+    goal = Goal("g", "desc", 3, lambda c: c.stats.getRoomsExplored())
+    assert goal.evaluate(makeContext(rooms=3)) is True
+    assert goal.isCompleted() is True
+
+
+def test_goal_not_completed_below_target():
+    goal = Goal("g", "desc", 5, lambda c: c.stats.getRoomsExplored())
+    assert goal.evaluate(makeContext(rooms=2)) is False
+    assert goal.isCompleted() is False
+
+
+def test_goal_evaluate_only_reports_fresh_completion():
+    goal = Goal("g", "desc", 1, lambda c: 1)
+    assert goal.evaluate(makeContext()) is True
+    assert goal.evaluate(makeContext()) is False
+
+
+def test_progress_is_clamped_to_target():
+    goal = Goal("g", "desc", 5, lambda c: c.stats.getRoomsExplored())
+    assert goal.getProgress(makeContext(rooms=99)) == 5
+
+
+def test_registry_provides_default_goals():
+    ids = [g.getIdentifier() for g in GoalRegistry().getGoals()]
+    assert "explore_5_rooms" in ids
+    assert "eat_10_food" in ids
+    assert "discover_3_entities" in ids
+    assert "experience_nightfall" in ids
+
+
+def test_evaluate_reports_newly_completed_once():
+    goals = makeGoals(rooms=5)
+    newly = [g.getDescription() for g in goals.evaluate()]
+    assert "Explore 5 rooms" in newly
+    assert goals.evaluate() == []
+
+
+def test_nightfall_goal_completes_at_night():
+    goals = makeGoals(phase="night")
+    ids = [g.getIdentifier() for g in goals.evaluate()]
+    assert "experience_nightfall" in ids
+
+
+def test_discovery_goal_uses_codex_count():
+    goals = makeGoals(discovered=["Bear", "Chicken", "Apple"])
+    ids = [g.getIdentifier() for g in goals.evaluate()]
+    assert "discover_3_entities" in ids
+
+
+def test_completed_count_and_total():
+    goals = makeGoals(rooms=5)
+    goals.evaluate()
+    assert goals.getCompletedCount() == 1
+    assert goals.getTotalCount() == len(GoalRegistry().getGoals())
+
+
+def test_completed_identifiers_roundtrip():
+    goals = makeGoals(rooms=5)
+    goals.evaluate()
+    completed = goals.getCompletedIdentifiers()
+    assert "explore_5_rooms" in completed
+
+    restored = makeGoals()
+    restored.setCompletedIdentifiers(completed)
+    explore = next(
+        g for g in restored.getGoals() if g.getIdentifier() == "explore_5_rooms"
+    )
+    assert explore.isCompleted() is True
+
+
+def test_reader_writer_roundtrip(tmp_path):
+    config = FakeConfig(str(tmp_path / "save"))
+    readerWriter = GoalsJsonReaderWriter(config)
+    readerWriter.save(["explore_5_rooms", "eat_10_food"])
+    assert sorted(readerWriter.load()) == ["eat_10_food", "explore_5_rooms"]
+
+
+def test_reader_returns_empty_when_missing(tmp_path):
+    config = FakeConfig(str(tmp_path / "nonexistent"))
+    assert GoalsJsonReaderWriter(config).load() == []


### PR DESCRIPTION
## Summary

Implements a lightweight, achievement-style **goal / progression system** that gives players a reason to engage with the systems Roam already has (exploration, food/survival, score, the Codex, day/night). Closes #375.

A new player can now work toward concrete objectives, get a toast when one completes, and review progress on the Stats screen — addressing the root "...now what?" UX gap without adding new game mechanics.

## What's included

**New `src/goals/` package**
- `goal.py` — `Goal` model (id, description, target, progress function). `evaluate()` returns `True` only on *fresh* completion so callers can react once.
- `goalContext.py` — snapshot of `stats`, `codex`, `dayNightCycle`, `tickCounter`, keeping goal conditions decoupled from wiring.
- `goalRegistry.py` — the default goals (12).
- `goals.py` — `Goals` manager (`@component`): `evaluate()`, progress/count getters, completed-id round-trip.
- `goalsJsonReaderWriter.py` + `schemas/goals.json` — per-save persistence, mirroring the Codex reader/writer (schema-validated, creates the save dir).

**Default goals**
- Exploration: Explore 5 / 25 / 100 rooms
- Food: Eat 10 / 50 food
- Codex: Discover a Chicken, Discover a Bear, Discover every creature (auto-scales to `len(ALL_LIVING_ENTITY_TYPES)`)
- Day/night: Experience nightfall, Witness the dawn
- Score: Reach a score of 25 / 100

**Wiring**
- `worldScreen.py` — resolves the goals components via the DI container (same pattern as Codex/DayNightCycle), evaluates goals each frame in `_updateGameState`, shows a **"Goal complete: …" status toast** on fresh completions, persists immediately, and loads completion state on init.
- `statsScreen.py` — renders a **Goals (X/Y)** section in two compact columns with per-goal progress and `[X]/[ ]` markers.

**Tests**
- `tests/goals/test_goals.py` — 15 tests: goal model, registry (incl. unique ids), manager, discovery / day-night / score conditions, completed-id round-trip, and reader/writer persistence.

## Design notes

- Default goals read **only state Roam already tracks**, so no new instrumentation was required.
- Fixed a goal that could never complete: the original "Discover 3 entities" was unreachable because only `Bear` and `Chicken` are ever discoverable — replaced with concrete creature-discovery goals.
- Goals are surfaced via **status toasts + the Stats screen** ("a section of an existing menu," per the issue). An always-on world-HUD widget is a natural follow-up but was kept out to avoid touching the large `_drawHud` path in this PR.

## Testing

- `python3 -m pytest tests/goals` → 15 passed
- `python3 -m pytest` (full suite) → **451 passed**, no regressions

Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_