### PR TITLE
docs: sync README clone URL and PLANNING.md with current code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,14 @@ logged in detail below.
 
 ## AI Agent Sessions
 
+### 2026-06-06 — Documentation sync: README clone URL and PLANNING.md drift (issues #374, #361)
+- **`README.md`:** Corrected the "Clone and Run" git URL from `https://github.com/Stephenson-Software/Roam.git` to the canonical `https://github.com/Preponderous-Software/roam.git` (matching the configured `origin` remote and the org used elsewhere in the README for the `graphik` / `py_env_lib` libraries).
+- **`PLANNING.md`:**
+  - Removed the stale "(unimplemented)" marker from the Crafting heading and documented the shipped recipe system (`Recipe` / `RecipeRegistry` in `src/crafting/`, listing all 8 recipes: Wood Floor, Bed, Stone Floor, Stone Bed, Fence, Campfire, Wheat Seed, Torch).
+  - Reconciled the Room Types list with `RoomType` in `src/world/roomType.py` — added the missing `Empty` type and corrected `Grass` → `Grassland`.
+- **Validation:** Documentation-only change; no `src/` or `tests/` files modified. `python -m compileall src -q` clean; full test suite re-run as a regression check (PASS).
+- **Learning Log:** `[integrated]` — no new convention; reinforces the existing doc-drift triage rule already in `copilot-instructions.md`.
+
 ### 2026-04-23 — Clean Code refactoring (names, DRY, dead code)
 - **`src/screen/worldScreen.py`:**
   - Removed duplicate `from math import ceil` import (already imported via `import math`); replaced the one `ceil()` call with `math.ceil()`.

--- a/PLANNING.md
+++ b/PLANNING.md
@@ -14,14 +14,16 @@ The map will be generated as the player explores.
 ### Inventory
 The player will have an inventory that can hold items. The player can open/close the inventory with the `i` key.
 
-### Crafting (unimplemented)
-The player will be able to craft items using the items in their inventory.
+### Crafting
+The player can craft items using the items in their inventory. Crafting is implemented via the `Recipe` and `RecipeRegistry` classes (`src/crafting/`). The current recipes are: Wood Floor, Bed, Stone Floor, Stone Bed, Fence, Campfire, Wheat Seed, and Torch.
 
 ### Food
 The player will be able to eat food to replenish energy. Food will be able to be found in the world or grown by the player.
 
 ## Room Types
-- Grass
+Defined by `RoomType` in `src/world/roomType.py`:
+- Empty
+- Grassland
 - Forest
 - Jungle
 - Mountain

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Right Mouse (inventory slot) | Select inventory slot (inventory screen)
 ### Clone
 1. If you don't have git installed, install it from [here](https://git-scm.com/downloads).
 2. Clone the repository with the following command:
-> git clone https://github.com/Stephenson-Software/Roam.git
+> git clone https://github.com/Preponderous-Software/roam.git
 
 ### Install Dependencies
 3. If you don't have python installed, install it from [here](https://www.python.org/downloads/).


### PR DESCRIPTION
## Summary

Documentation-only sync to remove two confirmed drifts between the docs and the current codebase.

- **`README.md`** — Corrected the "Clone and Run" git URL from `https://github.com/Stephenson-Software/Roam.git` to the canonical `https://github.com/Preponderous-Software/roam.git`. This matches the configured `origin` remote and the org the README already uses for the `graphik` / `py_env_lib` libraries. (Closes #374)
- **`PLANNING.md`** — Removed the stale "(unimplemented)" marker from the Crafting section and documented the shipped `Recipe` / `RecipeRegistry` system in `src/crafting/` (8 recipes: Wood Floor, Bed, Stone Floor, Stone Bed, Fence, Campfire, Wheat Seed, Torch). Reconciled the Room Types list with `RoomType` in `src/world/roomType.py` — added the missing `Empty` type and corrected `Grass` → `Grassland`. (Closes #361)
- **`CHANGELOG.md`** — Added a dated AI Agent Sessions entry.

## Test plan

- [x] `python3 -m compileall src -q` — clean
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — 451 passed (regression check; no `src/`/`tests/` files touched)
- [x] No new triple-backtick fenced blocks added to the edited `.md` files
- [x] Diff scope: 3 docs files, 14 insertions / 4 deletions — well under the scope ceiling

## Deferred this cycle (skip reasons)

- **#362** (copilot-instructions.md staleness) — deferred: that file is on the do-not-auto-merge list; better handled in its own PR.
- **#363, #369, #370** (bugs) — deferred per early-cycle docs/build bias; larger and need regression tests.
- **#365, #366, #373** (config/refactors) and **#364, #367, #371, #372** (test coverage) — deferred to keep this a coherent docs-only batch.
- Backlog **#346, #345, #338, #239, #234, #231** — feature/architecture work out of scope for an early docs cycle.

Closes #374
Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_