### PR TITLE
refactor: extract shared config-file rewrite loop into Config helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,13 @@ logged in detail below.
 
 ## AI Agent Sessions
 
+### 2026-06-06 — Deduplicate the config-file rewrite loop (issue #366)
+- **`src/config/config.py`:** Extracted the read → update-matching-keys → append-new-keys → write-back loop into a new `Config._writeKeyValues(self, savedValues, errorMessage)` helper. `saveWindowSize` now just builds its `savedValues` dict and delegates; the differing log message is passed through `errorMessage` so existing log behavior is preserved.
+- **`src/config/keyBindings.py`:** `KeyBindings.saveToConfigFile` now builds its prefixed `savedValues` dict and delegates to `config._writeKeyValues(...)`, dropping the verbatim-duplicated loop (~37 lines). Removed the now-unused `getLogger` import and module-level `_logger` (the only use was the warning that moved into `Config`).
+- **`tests/config/test_config.py`:** Added `test_write_key_values_updates_appends_and_preserves`, a direct test of the helper covering in-place key update (no duplicate), new-key append, and comment/blank-line preservation in a single call. The existing `saveWindowSize`/`saveToConfigFile` suites already exercise the helper through both public callers, providing regression coverage for the extraction.
+- **Validation:** `python3 -m compileall src -q` clean; `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — 461 passed (was 460; +1 new). Net −13 LOC across 3 files.
+- **Learning Log:** `[integrated]` — applied the cycle-2 lesson (roam-dev-loop#3): formatting was run scoped to the 3 changed files (`black`/`autoflake` on explicit paths) rather than tree-wide `./format.sh`, so no unrelated drift entered the diff.
+
 ### 2026-06-06 — Fix death-penalty rounding and un-skip silently-dead tests (issues #369, #371)
 - **`src/screen/worldScreen.py`:** Changed the on-death score penalty from `math.ceil(score * 0.9)` to `math.floor(score * 0.9)`. With `ceil`, the intended 10% penalty was a no-op for every score 1–9 (`ceil(0.9)` = 1, `ceil(8.1)` = 9) and only began reducing the score at 10 — exactly the early game where new players die most. `floor` makes the penalty always apply.
 - **`tests/screen/test_worldScreen_deathPenalty.py`** (new): Parametrized regression test pinning `removeEnergyAndCheckForPlayerDeath` at boundary scores (1→0, 9→8, 10→9, 25→22, 100→90); each case would fail under the old `ceil` logic. Also asserts the death counter increments.

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -240,9 +240,7 @@ class Config:
             debug=self.debug,
         )
 
-    def saveWindowSize(self, width, height):
-        width = max(int(width), self.MIN_WINDOW_SIZE)
-        height = max(int(height), self.MIN_WINDOW_SIZE)
+    def _writeKeyValues(self, savedValues, errorMessage):
         configFilePath = self.getConfigFilePath()
         lines = []
         if configFilePath.exists():
@@ -251,10 +249,6 @@ class Config:
             except (OSError, UnicodeDecodeError):
                 lines = []
 
-        savedValues = {
-            "savedWindowWidth": str(width),
-            "savedWindowHeight": str(height),
-        }
         updatedKeys = set()
         newLines = []
         for line in lines:
@@ -279,7 +273,16 @@ class Config:
             configFilePath.write_text("\n".join(newLines) + "\n", encoding="utf-8")
         except OSError as e:
             _logger.warning(
-                "failed to save window size to config file",
+                errorMessage,
                 error=str(e),
                 path=str(configFilePath),
             )
+
+    def saveWindowSize(self, width, height):
+        width = max(int(width), self.MIN_WINDOW_SIZE)
+        height = max(int(height), self.MIN_WINDOW_SIZE)
+        savedValues = {
+            "savedWindowWidth": str(width),
+            "savedWindowHeight": str(height),
+        }
+        self._writeKeyValues(savedValues, "failed to save window size to config file")

--- a/src/config/keyBindings.py
+++ b/src/config/keyBindings.py
@@ -1,7 +1,4 @@
 import pygame
-from gameLogging.logger import getLogger
-
-_logger = getLogger(__name__)
 
 
 # @author Copilot
@@ -128,43 +125,10 @@ class KeyBindings:
 
     def saveToConfigFile(self, config):
         """Save current keybindings to config.yml."""
-        configFilePath = config.getConfigFilePath()
-        lines = []
-        if configFilePath.exists():
-            try:
-                lines = configFilePath.read_text(encoding="utf-8").splitlines()
-            except (OSError, UnicodeDecodeError):
-                lines = []
-
         savedValues = {}
         for action, key in self.bindings.items():
             savedValues[self.CONFIG_PREFIX + action] = str(key)
 
-        updatedKeys = set()
-        newLines = []
-        for line in lines:
-            stripped = line.strip()
-            if stripped == "" or stripped.startswith("#"):
-                newLines.append(line)
-                continue
-            parts = stripped.split(":", 1)
-            if len(parts) == 2:
-                key = parts[0].strip()
-                if key in savedValues:
-                    newLines.append(key + ": " + savedValues[key])
-                    updatedKeys.add(key)
-                    continue
-            newLines.append(line)
-
-        for key, value in savedValues.items():
-            if key not in updatedKeys:
-                newLines.append(key + ": " + value)
-
-        try:
-            configFilePath.write_text("\n".join(newLines) + "\n", encoding="utf-8")
-        except OSError as e:
-            _logger.warning(
-                "failed to save key bindings to config file",
-                error=str(e),
-                path=str(configFilePath),
-            )
+        config._writeKeyValues(
+            savedValues, "failed to save key bindings to config file"
+        )

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -262,6 +262,26 @@ def test_save_window_size_clamps_to_minimum(tmp_path, monkeypatch):
     assert "savedWindowHeight: 400" in content
 
 
+def test_write_key_values_updates_appends_and_preserves(tmp_path, monkeypatch):
+    configFilePath = tmp_path / "config.yml"
+    configFilePath.write_text("# a comment\n\nexisting: old\n", encoding="utf-8")
+    monkeypatch.setattr(
+        Config, "getConfigFilePath", staticmethod(lambda: configFilePath)
+    )
+
+    config = Config()
+    config._writeKeyValues({"existing": "new", "added": "value"}, "failed to write")
+
+    content = configFilePath.read_text(encoding="utf-8")
+    # Existing key updated in place (no duplicate), new key appended
+    assert "existing: new" in content
+    assert "old" not in content
+    assert content.count("existing") == 1
+    assert "added: value" in content
+    # Comment and blank line preserved verbatim
+    assert "# a comment" in content
+
+
 def test_saved_window_size_is_loaded_on_init(tmp_path, monkeypatch):
     configFilePath = tmp_path / "config.yml"
     configFilePath.write_text(


### PR DESCRIPTION
## Summary

DRY refactor consolidating the duplicated config-file rewrite logic into a single source of truth.

- `Config.saveWindowSize` and `KeyBindings.saveToConfigFile` contained a **character-for-character identical** read → update-matching-keys → append-new-keys → write-back loop, differing only in how `savedValues` is built and the log message.
- Extracted the loop into `Config._writeKeyValues(self, savedValues, errorMessage)` (`src/config/config.py`). Both callers now build their `savedValues` dict and delegate; the differing warning text is threaded through `errorMessage` so existing log behavior is preserved.
- Removed `keyBindings.py`'s now-orphaned `getLogger` import and module-level `_logger` — its only use was the warning that moved into `Config`.

Net **−13 LOC** across 3 files; `keyBindings.saveToConfigFile` shrank from ~42 lines to ~8.

## Why

Any future change to the rewrite behavior (comment handling, quoting, encoding, atomic write) previously had to be made in two places and was easy to drift — the classic "bug fixed in one copy but not the other" trap.

## Test plan

- [x] `python3 -m compileall src -q` — clean
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — 461 passed (was 460; +1 new)
- [x] **Regression coverage:** the existing `test_config.py` (`saveWindowSize`) and `test_keyBindings.py` (`saveToConfigFile`) suites exercise the extracted helper through both public callers — update-in-place, append, whitespace-before-colon, comment preservation, round-trip — and all still pass unchanged.
- [x] Added `test_write_key_values_updates_appends_and_preserves` exercising the helper directly (update + append + comment/blank-line preservation in one call).
- [x] Formatting run scoped to the 3 changed files only (not tree-wide `format.sh`), so no unrelated drift entered the diff.

## Deferred this cycle (skip reasons)

- **#373** (room save-file path duplicated 5×) — the other refactor candidate; deferred because it spans 4 files including a persistence path (higher blast radius) and pairs naturally with the #370 atomic-write work, so it warrants its own focused PR.
- **#362** (copilot-instructions.md staleness), **#365** (config.yml drift) — touch do-not-auto-merge paths; better in their own PRs.
- **#370, #363** (save-corruption / schema-write bugs) — larger; need atomic-write design and dedicated regression tests.
- **#372, #367, #364, #368** (coverage / robustness) — out of this PR's theme.
- Backlog **#346, #345, #338, #239, #234, #231** — feature/architecture work out of scope.

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_