### PR TITLE
refactor: consolidate room save-file path into Config.getRoomFilePath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,16 @@ logged in detail below.
 
 ## AI Agent Sessions
 
+### 2026-06-06 — Consolidate room save-file path into a single source of truth (issue #373)
+- **`src/config/config.py`:** Added `Config.getRoomFilePath(self, x, y)` — the single canonical builder for the `<saveDir>/rooms/room_<x>_<y>.json` layout.
+- **`src/world/map.py`, `src/world/roomPreloader.py`:** Replaced inline hand-concatenated path builds in `getRoom` / the preloader with `self.config.getRoomFilePath(x, y)`.
+- **`src/screen/worldScreenPersistence.py`:** `saveRoomToFile` now calls `getRoomFilePath`; removed the dead `buildRoomPath` method (it had zero callers).
+- **`src/screen/worldScreen.py`:** Removed the `_buildRoomFilePath` helper and routed its two call sites (`saveRoomToFileAsync`, entity-move save) through `config.getRoomFilePath`.
+- **`tests/conftest.py`:** The shared `test_config` mock (`MagicMock(spec=Config)`) now delegates `getRoomFilePath` to the real `Config.getRoomFilePath` so path construction reflects each test's `pathToSaveDirectory` — required because the logic moved behind a Config method the mock would otherwise stub out.
+- **`tests/config/test_config.py`:** Added `test_get_room_file_path_format` pinning the exact on-disk path string (including negative coordinates) that all save/load call sites depend on.
+- **Validation:** `python3 -m compileall src -q` clean; `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — 462 passed (was 461; +1 new). The format string `"/rooms/room_"` now appears in exactly one place. Net −22 LOC.
+- **Learning Log:** `[not yet integrated]` — refines the cycle-2 lesson (roam-dev-loop#3): scoping formatters to *changed files* is still insufficient when a touched file carries pre-existing Black drift (`worldScreen.py` here), because `black <file>` reformats the whole file. The fix is to scope to changed *hunks* — after formatting, diff the touched file and revert any reformat that isn't part of the change (here, `worldScreen.py` was reverted and the two intended edits re-applied by hand).
+
 ### 2026-06-06 — Deduplicate the config-file rewrite loop (issue #366)
 - **`src/config/config.py`:** Extracted the read → update-matching-keys → append-new-keys → write-back loop into a new `Config._writeKeyValues(self, savedValues, errorMessage)` helper. `saveWindowSize` now just builds its `savedValues` dict and delegates; the differing log message is passed through `errorMessage` so existing log behavior is preserved.
 - **`src/config/keyBindings.py`:** `KeyBindings.saveToConfigFile` now builds its prefixed `savedValues` dict and delegates to `config._writeKeyValues(...)`, dropping the verbatim-duplicated loop (~37 lines). Removed the now-unused `getLogger` import and module-level `_logger` (the only use was the warning that moved into `Config`).

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -240,6 +240,13 @@ class Config:
             debug=self.debug,
         )
 
+    def getRoomFilePath(self, x, y):
+        """Return the path to a room's JSON save file: the single source of
+        truth for the on-disk room-file layout."""
+        return (
+            self.pathToSaveDirectory + "/rooms/room_" + str(x) + "_" + str(y) + ".json"
+        )
+
     def _writeKeyValues(self, savedValues, errorMessage):
         configFilePath = self.getConfigFilePath()
         lines = []

--- a/src/screen/worldScreen.py
+++ b/src/screen/worldScreen.py
@@ -304,22 +304,11 @@ class WorldScreen:
     def saveRoomToFile(self, room: Room):
         self.persistence.saveRoomToFile(room)
 
-    def _buildRoomFilePath(self, room: Room) -> str:
-        """Return the file path for a room's JSON save file."""
-        return (
-            self.config.pathToSaveDirectory
-            + "/rooms/room_"
-            + str(room.getX())
-            + "_"
-            + str(room.getY())
-            + ".json"
-        )
-
     def saveRoomToFileAsync(self, room: Room):
         """Save a room to file on the background thread (non-blocking).
         Prepares the JSON snapshot on the main thread to avoid dict-iteration
         races, then writes the file in the background."""
-        roomPath = self._buildRoomFilePath(room)
+        roomPath = self.config.getRoomFilePath(room.getX(), room.getY())
         try:
             roomJson = self.roomJsonReaderWriter.generateJsonForRoom(room)
         except Exception as e:
@@ -1858,7 +1847,9 @@ class WorldScreen:
         except Exception as e:
             _logger.error("error preparing room snapshot for save", error=str(e))
             roomJson = None
-        roomPath = self._buildRoomFilePath(self.currentRoom)
+        roomPath = self.config.getRoomFilePath(
+            self.currentRoom.getX(), self.currentRoom.getY()
+        )
         self._saveExecutor.submit(self._doSave, roomJson, roomPath)
 
     def saveSynchronous(self):

--- a/src/screen/worldScreenPersistence.py
+++ b/src/screen/worldScreenPersistence.py
@@ -129,14 +129,7 @@ class WorldScreenPersistence:
             self.player.setInventory(inventory)
 
     def saveRoomToFile(self, room):
-        roomPath = (
-            self.config.pathToSaveDirectory
-            + "/rooms/room_"
-            + str(room.getX())
-            + "_"
-            + str(room.getY())
-            + ".json"
-        )
+        roomPath = self.config.getRoomFilePath(room.getX(), room.getY())
         _logger.info("saving room", path=roomPath)
         if not os.path.exists(self.config.pathToSaveDirectory + "/rooms"):
             os.makedirs(self.config.pathToSaveDirectory + "/rooms")
@@ -144,13 +137,3 @@ class WorldScreenPersistence:
         jsonRoom = self.roomJsonReaderWriter.generateJsonForRoom(room)
         with open(roomPath, "w") as outfile:
             json.dump(jsonRoom, outfile, indent=4)
-
-    def buildRoomPath(self, roomX, roomY):
-        return (
-            self.config.pathToSaveDirectory
-            + "/rooms/room_"
-            + str(roomX)
-            + "_"
-            + str(roomY)
-            + ".json"
-        )

--- a/src/world/map.py
+++ b/src/world/map.py
@@ -53,14 +53,7 @@ class Map:
                 return self._roomIndex[key]
 
         # attempt to load room if file exists, otherwise generate new room
-        nextRoomPath = (
-            self.config.pathToSaveDirectory
-            + "/rooms/room_"
-            + str(x)
-            + "_"
-            + str(y)
-            + ".json"
-        )
+        nextRoomPath = self.config.getRoomFilePath(x, y)
         if os.path.exists(nextRoomPath):
             if self._roomJsonReaderWriterFactory is not None:
                 roomJsonReaderWriter = self._roomJsonReaderWriterFactory()

--- a/src/world/roomPreloader.py
+++ b/src/world/roomPreloader.py
@@ -69,14 +69,7 @@ class RoomPreloader:
             if gameMap.hasRoom(x, y):
                 return
 
-            nextRoomPath = (
-                self.config.pathToSaveDirectory
-                + "/rooms/room_"
-                + str(x)
-                + "_"
-                + str(y)
-                + ".json"
-            )
+            nextRoomPath = self.config.getRoomFilePath(x, y)
             if os.path.exists(nextRoomPath):
                 roomJsonReaderWriter = self._roomJsonReaderWriterFactory()
                 room = roomJsonReaderWriter.loadRoom(nextRoomPath)

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -282,6 +282,14 @@ def test_write_key_values_updates_appends_and_preserves(tmp_path, monkeypatch):
     assert "# a comment" in content
 
 
+def test_get_room_file_path_format():
+    config = Config()
+    config.pathToSaveDirectory = "saves/myworld"
+    # Pins the on-disk room-file layout that all save/load call sites depend on
+    assert config.getRoomFilePath(2, -3) == "saves/myworld/rooms/room_2_-3.json"
+    assert config.getRoomFilePath(0, 0) == "saves/myworld/rooms/room_0_0.json"
+
+
 def test_saved_window_size_is_loaded_on_init(tmp_path, monkeypatch):
     configFilePath = tmp_path / "config.yml"
     configFilePath.write_text(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,9 @@ def test_config(tmp_path):
     config.dayNightCycleLengthTicks = 54000
     config.cropGrowthTicks = 1800
     config.ticksPerSecond = 30
+    # Delegate to the real implementation so room-path construction reflects
+    # the (possibly per-test overridden) pathToSaveDirectory.
+    config.getRoomFilePath = lambda x, y: Config.getRoomFilePath(config, x, y)
     return config
 
 


### PR DESCRIPTION
## Summary

DRY refactor giving the room save-file path layout (`<saveDir>/rooms/room_<x>_<y>.json`) a single source of truth.

The path was hand-concatenated in **five** places across four files, with two redundant helpers:
- `src/world/map.py` (`getRoom`), `src/world/roomPreloader.py`, `src/screen/worldScreenPersistence.py` (`saveRoomToFile`) built it inline.
- `src/screen/worldScreen.py` had `_buildRoomFilePath` (used at 2 sites); `worldScreenPersistence.py` had `buildRoomPath` (**zero callers — dead code**).

Changes:
- Added `Config.getRoomFilePath(self, x, y)` as the canonical builder (`Config` already owns `pathToSaveDirectory`).
- Routed all five sites through it; removed both redundant helpers.
- After this change `"/rooms/room_"` appears in exactly **one** place.

## Why

The on-disk room-file layout was encoded in five spots. Any change to it (a directory rename, filename scheme change, or the atomic-write rework in #370) had to be made consistently in all five or the game would read from one location and write to another. This collapses it to one.

## Test plan

- [x] `python3 -m compileall src -q` — clean
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — 462 passed (was 461; +1 new)
- [x] **Behavior preservation:** new `test_get_room_file_path_format` pins the exact path string (including negative coords); the existing `test_map.py` / `test_roomPreloader.py` load/generate suites exercise the consolidated path end-to-end and pass unchanged.
- [x] `tests/conftest.py`: the shared `test_config` mock now delegates `getRoomFilePath` to the real `Config` implementation, so path construction still reflects each test's `pathToSaveDirectory` (necessary now that the logic sits behind a Config method the `MagicMock(spec=Config)` would otherwise stub).
- [x] Formatting scoped to changed **hunks** — `worldScreen.py` had pre-existing Black drift on unrelated lines, so it was reverted and the two intended edits re-applied by hand to keep the diff focused.

## Note on do-not-auto-merge

`worldScreenPersistence.py` is persistence-adjacent, but the **on-disk format is unchanged** — only how the path string is assembled. The path output is byte-identical (pinned by the new test), so this does not alter save files.

## Deferred this cycle (skip reasons)

- **#370, #363** (save-corruption / schema-write bugs) — larger; #373 was done first to give them a single path helper to build atomic writes on.
- **#362** (copilot-instructions staleness), **#365** (config.yml drift) — do-not-auto-merge paths; own PRs.
- **#372, #367, #364, #368** (coverage / robustness) — out of this PR's theme.
- Backlog **#346, #345, #338, #239, #234, #231** — feature/architecture work out of scope.

Closes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_