### PR TITLE
fix: don't crash the render loop on a missing or unreadable asset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,12 @@ logged in detail below.
 
 ## AI Agent Sessions
 
+### 2026-06-06 — Harden render loop against missing/unreadable assets (issue #368)
+- **`src/entity/drawableEntity.py`:** `getImage` previously called `pygame.image.load` with no error handling; a missing, renamed, or corrupt sprite raised `pygame.error` / `FileNotFoundError` straight out of the hot render path (`room.py`, `worldScreen.py`, `inventoryScreen.py`), hard-crashing an in-progress, auto-saving session. The load is now wrapped in `try`/`except (pygame.error, FileNotFoundError)`: on failure it logs the offending `imagePath` once (structured `getLogger` warning) and caches a magenta placeholder surface from the new `_createFallbackSurface()` helper, so the game degrades gracefully and the missing asset is visible rather than fatal. The fallback is cached per path, so the failing load is not retried every frame and the warning is logged only once.
+- **`tests/entity/test_drawableEntity.py`:** Added a headless-pygame fixture plus two tests: a missing asset returns a `pygame.Surface` of the fallback size (would raise under the old unguarded load), and the fallback is cached (the second `getImage` returns the same surface, confirming no per-frame retry). Both pop their cache keys to keep the class-level `_imageCache` clean.
+- **Validation:** `python3 -m compileall src -q` clean; `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — 464 passed (was 462; +2 new).
+- **Learning Log:** `[integrated]` — applied the cycle-4 refinements: formatting was scoped to the two changed files and the diff verified at the hunk level (no pre-existing drift in this file to leak); no `print()`, structured `getLogger` used per logging conventions.
+
 ### 2026-06-06 — Consolidate room save-file path into a single source of truth (issue #373)
 - **`src/config/config.py`:** Added `Config.getRoomFilePath(self, x, y)` — the single canonical builder for the `<saveDir>/rooms/room_<x>_<y>.json` layout.
 - **`src/world/map.py`, `src/world/roomPreloader.py`:** Replaced inline hand-concatenated path builds in `getRoom` / the preloader with `self.config.getRoomFilePath(x, y)`.

--- a/src/entity/drawableEntity.py
+++ b/src/entity/drawableEntity.py
@@ -1,11 +1,15 @@
 import pygame
 from lib.pyenvlib.entity import Entity
+from gameLogging.logger import getLogger
+
+_logger = getLogger(__name__)
 
 
 # @author Daniel McCoy Stephenson
 # @since August 5th, 2022
 class DrawableEntity(Entity):
     _imageCache = {}
+    _FALLBACK_SIZE = 32
 
     def __init__(self, name, imagePath, solid=False):
         Entity.__init__(self, name)
@@ -17,10 +21,30 @@ class DrawableEntity(Entity):
 
     def getImage(self):
         if self.imagePath not in DrawableEntity._imageCache:
-            DrawableEntity._imageCache[self.imagePath] = pygame.image.load(
-                self.imagePath
-            )
+            try:
+                DrawableEntity._imageCache[self.imagePath] = pygame.image.load(
+                    self.imagePath
+                )
+            except (pygame.error, FileNotFoundError) as e:
+                _logger.warning(
+                    "failed to load image asset; using placeholder",
+                    imagePath=self.imagePath,
+                    error=str(e),
+                )
+                DrawableEntity._imageCache[
+                    self.imagePath
+                ] = DrawableEntity._createFallbackSurface()
         return DrawableEntity._imageCache[self.imagePath]
+
+    @staticmethod
+    def _createFallbackSurface():
+        # A visibly-wrong magenta square so a missing asset is obvious in-game
+        # rather than crashing the render loop. Cached per path so the failing
+        # load is not retried and the warning is logged only once.
+        size = DrawableEntity._FALLBACK_SIZE
+        surface = pygame.Surface((size, size))
+        surface.fill((255, 0, 255))
+        return surface
 
     def getImagePath(self):
         return self.imagePath

--- a/tests/entity/test_drawableEntity.py
+++ b/tests/entity/test_drawableEntity.py
@@ -1,4 +1,18 @@
+import os
+
+os.environ["SDL_VIDEODRIVER"] = "dummy"
+os.environ["SDL_AUDIODRIVER"] = "dummy"
+import pygame
+import pytest
+
 from src.entity.drawableEntity import DrawableEntity
+
+
+@pytest.fixture(scope="module", autouse=True)
+def init_pygame():
+    pygame.init()
+    yield
+    pygame.quit()
 
 
 def test_initialization():
@@ -6,3 +20,33 @@ def test_initialization():
 
     assert drawableEntity.getName() == "test"
     assert drawableEntity.getImagePath() == "myimagepath.png"
+
+
+def test_get_image_returns_placeholder_for_missing_asset():
+    missingPath = "assets/images/__does_not_exist__.png"
+    DrawableEntity._imageCache.pop(missingPath, None)
+    entity = DrawableEntity("missing", missingPath)
+
+    # A missing asset must not propagate out of the render path
+    image = entity.getImage()
+
+    assert isinstance(image, pygame.Surface)
+    assert image.get_size() == (
+        DrawableEntity._FALLBACK_SIZE,
+        DrawableEntity._FALLBACK_SIZE,
+    )
+    DrawableEntity._imageCache.pop(missingPath, None)
+
+
+def test_get_image_caches_fallback_without_retry():
+    missingPath = "assets/images/__also_missing__.png"
+    DrawableEntity._imageCache.pop(missingPath, None)
+    entity = DrawableEntity("missing", missingPath)
+
+    first = entity.getImage()
+    second = entity.getImage()
+
+    # Same cached surface returned — the failing load is not retried each frame
+    assert first is second
+    assert missingPath in DrawableEntity._imageCache
+    DrawableEntity._imageCache.pop(missingPath, None)


### PR DESCRIPTION
## Summary

Hardens rendering so a single bad sprite degrades gracefully instead of crashing an in-progress session.

`DrawableEntity.getImage` (`src/entity/drawableEntity.py`) called `pygame.image.load` with no error handling. A missing, renamed, or corrupt asset raised `pygame.error` / `FileNotFoundError` straight out of the hot render path (`room.py:87`, `worldScreen.py:1422`/`:1580`, `inventoryScreen.py:141`/`:493`) — a hard crash mid-session, with the image cache ensuring the failure was deterministic per asset.

Changes:
- Wrapped the load in `try`/`except (pygame.error, FileNotFoundError)`.
- On failure: log the offending `imagePath` once (structured `getLogger` warning) and cache a magenta placeholder `pygame.Surface` from the new `_createFallbackSurface()` helper.
- The fallback is cached per path, so the failing load is not retried each frame and the warning is logged exactly once.

## Why a magenta placeholder

It keeps the game running and makes the missing texture obvious in-game (the classic "missing texture" colour) rather than silently invisible or fatal.

## Test plan

- [x] `python3 -m compileall src -q` — clean
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — 464 passed (was 462; +2 new)
- [x] **Regression evidence:** `test_get_image_returns_placeholder_for_missing_asset` calls `getImage` on a nonexistent path and asserts a fallback `Surface` is returned — this **raises under the old unguarded load**. `test_get_image_caches_fallback_without_retry` asserts the second call returns the same cached surface (no per-frame retry).
- [x] Formatting scoped to the 2 changed files and verified at the hunk level.

## Deferred this cycle (skip reasons)

- **#370, #363** (corrupt-save crash / invalid-data-written) — the remaining save-durability bugs; larger, need atomic-write design and their own regression tests.
- **#362** (copilot-instructions staleness), **#365** (config.yml drift) — do-not-auto-merge paths; own PRs.
- **#364** (WorldScreenPersistence coverage) — partially stale: it suggests testing `buildRoomPath`, which was removed as dead code in #380; noted on the issue for re-scoping.
- **#372, #367** (Room/Inventory/MapImageGenerator coverage) — out of this PR's theme.
- Backlog **#346, #345, #338, #239, #234, #231** — feature/architecture work out of scope.

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_