### PR TITLE
feat: Add a tag-triggered release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,123 @@
+name: Release
+
+# Build the standalone Windows installer + portable zip and the macOS .dmg, and
+# attach them to a GitHub Release whenever a version tag (e.g. v0.8.0) is pushed.
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create the release if it does not exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${{ github.ref_name }}"
+          if ! gh release view "$tag" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            gh release create "$tag" \
+              --repo "${{ github.repository }}" \
+              --title "Roam $tag" \
+              --generate-notes \
+              --verify-tag
+          fi
+
+  windows:
+    needs: create-release
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies + PyInstaller
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pyinstaller
+
+      - name: Generate the icon
+        shell: pwsh
+        run: |
+          python -c "from PIL import Image; Image.open('src/media/icon.PNG').save('src/media/icon.ico', sizes=[(16,16),(32,32),(48,48),(256,256)])"
+
+      - name: Build the executable
+        shell: pwsh
+        run: pyinstaller roam.spec --noconfirm
+
+      - name: Build the installer and portable zip
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $version = "${{ github.ref_name }}".TrimStart("v")
+          $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
+          & $iscc "/DMyAppVersion=$version" roam.iss
+          if ($LASTEXITCODE -ne 0) { throw "ISCC failed (exit $LASTEXITCODE)" }
+          Copy-Item "installer-output/RoamSetup.exe" "Roam-$version-Setup.exe"
+          Compress-Archive -Path "dist/Roam/*" -DestinationPath "Roam-$version-windows-portable.zip" -Force
+
+      - name: Attach Windows artifacts to the release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $version = "${{ github.ref_name }}".TrimStart("v")
+          gh release upload "${{ github.ref_name }}" `
+            "Roam-$version-Setup.exe" `
+            "Roam-$version-windows-portable.zip" `
+            --repo "${{ github.repository }}" --clobber
+
+  macos:
+    needs: create-release
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies + PyInstaller
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pyinstaller
+
+      - name: Generate the .icns icon
+        run: |
+          set -euo pipefail
+          iconset=icon.iconset
+          mkdir -p "$iconset"
+          for size in 16 32 128 256 512; do
+            double=$((size * 2))
+            sips -z $size  $size   src/media/icon.PNG --out "$iconset/icon_${size}x${size}.png"
+            sips -z $double $double src/media/icon.PNG --out "$iconset/icon_${size}x${size}@2x.png"
+          done
+          iconutil -c icns "$iconset" -o src/media/icon.icns
+
+      - name: Build the .app and .dmg
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          pyinstaller roam.spec --noconfirm
+          hdiutil create -volname Roam -srcfolder dist/Roam.app -ov -format UDZO "Roam-$version.dmg"
+
+      - name: Attach macOS artifact to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          gh release upload "${{ github.ref_name }}" "Roam-$version.dmg" \
+            --repo "${{ github.repository }}" --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ logged in detail below.
 
 | Date | Commits | Summary |
 |------|---------|---------|
+| 2026-06-07 | 1+ | feat: Add a release workflow — on a `v*` tag push, build and attach `Roam-<version>-Setup.exe`, a portable Windows zip, and `Roam-<version>.dmg` to an auto-generated GitHub Release (so distributables persist beyond the ~90-day CI-artifact retention) |
 | 2026-06-07 | 1+ | feat: Package Roam for macOS (#394) — add a macOS-only PyInstaller `BUNDLE` step to `roam.spec` (`dist/Roam.app`), route user data to `~/Library/Application Support/Roam` on macOS (`Config.getUserDataDirectory`/`getSavesBaseDirectory`), and add a `macos-latest` CI job that builds the `.app`, runs `--selftest`, builds a `.dmg`, and uploads both |
 | 2026-06-07 | 1+ | feat: Add a Windows setup wizard installer (#385, phase 2) — `roam.iss` Inno Setup script wrapping the PyInstaller build into `RoamSetup.exe` (installs to Program Files, Start Menu + optional Desktop shortcuts, uninstaller/Add-Remove Programs); CI builds the installer and runs a silent install → frozen `--selftest` → uninstall round-trip and uploads `RoamSetup.exe`. Completes #385 |
 | 2026-06-07 | 1+ | feat: Store all writable user data under %APPDATA% on Windows — add `Config.getUserDataDirectory()` and route config + screenshots through it (joining saves, which already used %APPDATA%), seed the writable `config.yml` from the bundled defaults on first run, and relocate screenshots; lets config/keybinding writes and screenshots work when installed to a read-only location like Program Files |
@@ -83,6 +84,12 @@ logged in detail below.
 | 2022-08-08 | 21 | Create version.txt; Update README.md; Modified README. (+9 more) |
 
 ## AI Agent Sessions
+
+### 2026-06-07 — Add a tag-triggered release workflow
+- **`.github/workflows/release.yml` (new):** Triggers on `v*` tag pushes (`permissions: contents: write`). A `create-release` job creates the GitHub Release for the tag (idempotent — skipped if it already exists) with `gh release create --generate-notes`. A `windows` job (windows-latest) builds the PyInstaller exe, compiles the Inno Setup installer with the tag's version (`ISCC /DMyAppVersion=<tag without leading v>`), produces `Roam-<version>-Setup.exe` and a `Roam-<version>-windows-portable.zip`, and attaches them via `gh release upload --clobber`. A `macos` job (macos-latest) builds the `.app`, packages `Roam-<version>.dmg`, and attaches it. All uploads use the built-in `GITHUB_TOKEN`; no third-party actions.
+- **Rationale:** CI build artifacts expire (~90 days), so the only durable place for end-user downloads is a Release. The build steps mirror the already-green `package` / `package-macos` jobs; the new pieces are tag→version extraction and the `gh release` create/upload calls.
+- **`README.md`:** Added a Downloads section pointing to the Releases page and noting the artifacts are unsigned (SmartScreen/Gatekeeper — #393/#396).
+- **Validation:** YAML validated locally (`yaml.safe_load`); the workflow only runs on tag pushes, so it is not exercised by PR CI. The per-OS build steps are identical to the existing, passing package jobs. A real end-to-end check requires pushing a version tag (a maintainer action that publishes a public Release), so it is intentionally left for the user rather than triggered here. `.github/workflows/` is on the do-not-auto-merge list → manual review.
 
 ### 2026-06-07 — Package Roam for macOS (.app + .dmg) (#394)
 - **`src/config/config.py`:** Added a macOS branch (`sys.platform == "darwin"`) to `getUserDataDirectory()` → `~/Library/Application Support/Roam`, and to `getSavesBaseDirectory()` → that dir's `saves`. Mirrors the Windows `%APPDATA%` handling so a `.app` in a read-only `/Applications` can still persist config, saves, and screenshots. The existing Windows and from-source branches are untouched (the Windows no-APPDATA fallback still returns `"saves"`/the bundle dir). Added `import sys`.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Right Mouse (inventory slot) | Select inventory slot (inventory screen)
 ## Run Script (Linux Only)
 There is also a run.sh script you can execute if you're on linux which will automatically attempt to install the dependencies for you.
 
+## Downloads
+Prebuilt installers are attached to each tagged release on the [Releases page](https://github.com/Preponderous-Software/roam/releases): `Roam-<version>-Setup.exe` (Windows installer), `Roam-<version>-windows-portable.zip` (no-install Windows build), and `Roam-<version>.dmg` (macOS). These are built automatically by the release workflow when a `v*` tag is pushed. They are not yet code-signed, so Windows SmartScreen / macOS Gatekeeper will warn on first run (see issues #393 / #396).
+
 ## Windows Installation Wizard
 On Windows you can use the `install.ps1` wizard instead of running the steps above by hand. It checks that Python and pip are available, installs pygame and the rest of the dependencies, and creates Desktop and Start Menu shortcuts so you can launch the game without using the command line.
 


### PR DESCRIPTION
## Summary
Publishes durable, downloadable installers to GitHub Releases — CI build artifacts expire (~90 days), so a Release is the right home for end-user downloads.

On a **`v*` tag push** (e.g. `v0.8.0`), `release.yml`:
- **`create-release`** — creates the Release for the tag with auto-generated notes (idempotent).
- **`windows`** — builds the exe, compiles the Inno Setup installer at the tag's version (`ISCC /DMyAppVersion=`), and attaches `Roam-<version>-Setup.exe` + `Roam-<version>-windows-portable.zip`.
- **`macos`** — builds the `.app` and attaches `Roam-<version>.dmg`.

Uploads use the built-in `GITHUB_TOKEN` via the `gh` CLI (no third-party actions). Build steps mirror the already-green `package` / `package-macos` jobs.

## How to use it
```
git tag v0.8.0
git push origin v0.8.0
```
…then the Release appears with all three artifacts attached.

## Test plan
- [x] YAML validated locally; existing PR CI (`test`, `windows-installer`, `package`, `package-macos`) is unaffected — no source changed (`pytest` → 493 passed).
- [ ] **End-to-end requires pushing a real version tag**, which publishes a public Release — a maintainer action, so I've left it for you rather than triggering it. The per-OS build steps are identical to the existing passing jobs; the only new logic is tag→version extraction and the `gh release` calls. Happy to do a dry run against a throwaway tag (e.g. `v0.0.0-test`, deleted after) if you'd like it proven first.

## Notes
- Touches `.github/workflows/`, so **manual merge**.
- Released artifacts are unsigned (SmartScreen/Gatekeeper) until #393 / #396 are done; the README Downloads section notes this.

---
*drafted by Claude on behalf of Daniel Stephenson*