### PR TITLE
chore: Bump GitHub Actions to their Node 24 majors

### DIFF
--- a/.github/workflows/macos-package.yml
+++ b/.github/workflows/macos-package.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -65,13 +65,13 @@ jobs:
           test -f dist/Roam.dmg
 
       - name: Upload the .app bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: roam-macos-app
           path: dist/Roam.app
 
       - name: Upload the .dmg
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: roam-macos-dmg
           path: dist/Roam.dmg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create the release if it does not exist
         env:
@@ -32,10 +32,10 @@ jobs:
     needs: create-release
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -81,10 +81,10 @@ jobs:
     needs: create-release
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           # Match the Linux Tests job. requirements.txt now uses lower bounds,
           # so the wizard's `pip install -r requirements.txt` resolves modern
@@ -61,10 +61,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -100,7 +100,7 @@ jobs:
           Write-Host "Frozen bundle selftest passed."
 
       - name: Upload the build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: roam-windows
           path: dist/Roam/
@@ -143,7 +143,7 @@ jobs:
           Write-Host "Install / self-test / uninstall round-trip passed."
 
       - name: Upload the installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: roam-setup
           path: installer-output/RoamSetup.exe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ logged in detail below.
 
 | Date | Commits | Summary |
 |------|---------|---------|
+| 2026-06-07 | 1+ | chore: Bump GitHub Actions to their Node 24 majors across all workflows — `actions/checkout` v4→v6, `actions/setup-python` v5→v6, `actions/upload-artifact` v4→v7 — clearing the Node.js 20 deprecation warnings |
 | 2026-06-07 | 1+ | feat: Add a release workflow — on a `v*` tag push, build and attach `Roam-<version>-Setup.exe`, a portable Windows zip, and `Roam-<version>.dmg` to an auto-generated GitHub Release (so distributables persist beyond the ~90-day CI-artifact retention) |
 | 2026-06-07 | 1+ | feat: Package Roam for macOS (#394) — add a macOS-only PyInstaller `BUNDLE` step to `roam.spec` (`dist/Roam.app`), route user data to `~/Library/Application Support/Roam` on macOS (`Config.getUserDataDirectory`/`getSavesBaseDirectory`), and add a `macos-latest` CI job that builds the `.app`, runs `--selftest`, builds a `.dmg`, and uploads both |
 | 2026-06-07 | 1+ | feat: Add a Windows setup wizard installer (#385, phase 2) — `roam.iss` Inno Setup script wrapping the PyInstaller build into `RoamSetup.exe` (installs to Program Files, Start Menu + optional Desktop shortcuts, uninstaller/Add-Remove Programs); CI builds the installer and runs a silent install → frozen `--selftest` → uninstall round-trip and uploads `RoamSetup.exe`. Completes #385 |
@@ -84,6 +85,10 @@ logged in detail below.
 | 2022-08-08 | 21 | Create version.txt; Update README.md; Modified README. (+9 more) |
 
 ## AI Agent Sessions
+
+### 2026-06-07 — Bump GitHub Actions to Node 24 majors
+- **`.github/workflows/{tests,windows-installer,macos-package,release}.yml`:** Bumped `actions/checkout@v4 → @v6`, `actions/setup-python@v5 → @v6`, and `actions/upload-artifact@v4 → @v7` (the current latest majors, all on Node 24), clearing the Node.js 20 deprecation warnings GitHub emitted on every run (Node 20 is force-removed from runners on 2026-09-16). Versions were confirmed against `repos/actions/<name>/releases/latest`.
+- **Validation:** Pure CI-config change; no source touched. The `checkout`/`setup-python`/`upload-artifact` bumps are exercised directly by this PR's `test`, `windows-installer`, `package`, and `package-macos` jobs; `release.yml` (tag-only) uses the same `checkout`/`setup-python` versions proven by those jobs. `.github/workflows/` is on the do-not-auto-merge list → manual review.
 
 ### 2026-06-07 — Add a tag-triggered release workflow
 - **`.github/workflows/release.yml` (new):** Triggers on `v*` tag pushes (`permissions: contents: write`). A `create-release` job creates the GitHub Release for the tag (idempotent — skipped if it already exists) with `gh release create --generate-notes`. A `windows` job (windows-latest) builds the PyInstaller exe, compiles the Inno Setup installer with the tag's version (`ISCC /DMyAppVersion=<tag without leading v>`), produces `Roam-<version>-Setup.exe` and a `Roam-<version>-windows-portable.zip`, and attaches them via `gh release upload --clobber`. A `macos` job (macos-latest) builds the `.app`, packages `Roam-<version>.dmg`, and attaches it. All uploads use the built-in `GITHUB_TOKEN`; no third-party actions.


### PR DESCRIPTION
## Summary
Clears the Node.js 20 deprecation warnings GitHub now emits on every workflow run (Node 20 is force-removed from runners on 2026-09-16).

Bumped to the current latest majors (all Node 24), confirmed against each action's `releases/latest`:
- `actions/checkout` v4 → **v6**
- `actions/setup-python` v5 → **v6**
- `actions/upload-artifact` v4 → **v7**

…across `tests.yml`, `windows-installer.yml`, `macos-package.yml`, and `release.yml`.

## Test plan
- [x] Pure CI-config change; no source touched.
- [ ] CI on this PR exercises the new `checkout`/`setup-python`/`upload-artifact` versions directly (`test`, `windows-installer`, `package`, `package-macos`). `release.yml` is tag-only but uses the same checkout/setup-python versions proven by those jobs.

Touches `.github/workflows/`, so **manual merge**.

---
*drafted by Claude on behalf of Daniel Stephenson*