### PR TITLE
docs: Surface the recommended install path; disambiguate the two "wizards"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ logged in detail below.
 
 | Date | Commits | Summary |
 |------|---------|---------|
+| 2026-06-07 | 1+ | docs: Lead the README with the recommended prebuilt download (no Python), reframe the clone steps as "Run from Source (for developers)", and rename the `install.ps1` section to a "setup script" distinct from the `RoamSetup.exe` installer — fixes the information scent and the two-things-both-called-"wizard" naming collision (closes #404) |
 | 2026-06-07 | 1+ | test: Add unit-test coverage for `Room.tickExcrement` (spawn/decay/grass-blocking branches), `Inventory.hasAvailableSlotFor` (empty/matching-stack/full), and `MapImageGenerator` coordinate + bounds math; align `test_room.py` entity imports to the production `entity.*` root so `isinstance` checks match room-created entities; +18 tests (issues #372, #367) |
 | 2026-06-07 | 1+ | chore: Bump GitHub Actions to their Node 24 majors across all workflows — `actions/checkout` v4→v6, `actions/setup-python` v5→v6, `actions/upload-artifact` v4→v7 — clearing the Node.js 20 deprecation warnings |
 | 2026-06-07 | 1+ | feat: Add a release workflow — on a `v*` tag push, build and attach `Roam-<version>-Setup.exe`, a portable Windows zip, and `Roam-<version>.dmg` to an auto-generated GitHub Release (so distributables persist beyond the ~90-day CI-artifact retention) |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,16 @@ Right Mouse (inventory slot) | Select inventory slot (inventory screen)
 
 > **Tip:** Keybindings are configurable in-game. Open the options menu and select **Controls** to view or remap bindings. Remapped keys are respected across all screens (world, inventory, stats, etc.).
 
-## Clone and Run
+## Download & Install (recommended)
+The easiest way to play Roam — no Python and no command line. Grab the latest build from the [Releases page](https://github.com/Preponderous-Software/roam/releases):
+
+- **Windows:** `Roam-<version>-Setup.exe` — a standard installer that adds Start Menu/Desktop shortcuts and an uninstaller. Prefer no install? Use `Roam-<version>-windows-portable.zip`.
+- **macOS:** `Roam-<version>.dmg` — open it and drag `Roam.app` to Applications.
+
+These builds aren't code-signed yet, so on first run Windows SmartScreen shows an "unknown publisher" prompt (choose **More info → Run anyway**) and macOS Gatekeeper may block the app (right-click it → **Open**). See issues #393 / #396.
+
+## Run from Source (for developers)
+Want the latest code, or to contribute? Run Roam from a clone. (To just play, use the [download above](#download--install-recommended).)
 ### Clone
 1. If you don't have git installed, install it from [here](https://git-scm.com/downloads).
 2. Clone the repository with the following command:
@@ -49,11 +58,8 @@ Right Mouse (inventory slot) | Select inventory slot (inventory screen)
 ## Run Script (Linux Only)
 There is also a run.sh script you can execute if you're on linux which will automatically attempt to install the dependencies for you.
 
-## Downloads
-Prebuilt installers are attached to each tagged release on the [Releases page](https://github.com/Preponderous-Software/roam/releases): `Roam-<version>-Setup.exe` (Windows installer), `Roam-<version>-windows-portable.zip` (no-install Windows build), and `Roam-<version>.dmg` (macOS). These are built automatically by the release workflow when a `v*` tag is pushed. They are not yet code-signed, so Windows SmartScreen / macOS Gatekeeper will warn on first run (see issues #393 / #396).
-
-## Windows Installation Wizard
-On Windows you can use the `install.ps1` wizard instead of running the steps above by hand. It checks that Python and pip are available, installs pygame and the rest of the dependencies, and creates Desktop and Start Menu shortcuts so you can launch the game without using the command line.
+## Windows setup script (run from source)
+If you're [running from source](#run-from-source-for-developers) on Windows, `install.ps1` is a setup *script* — the from-source counterpart to `run.sh`. It checks that Python and pip are available, installs the dependencies, and creates Desktop and Start Menu shortcuts so you can launch the game without using the command line. (For a normal install, use the `RoamSetup.exe` **installer** from [Download & Install](#download--install-recommended) instead — it needs no Python.)
 
 1. [Clone or download](#clone) the repository.
 2. Right-click `install.ps1` and choose **Run with PowerShell**.


### PR DESCRIPTION
## Summary
Fixes the README information scent for the Windows install flow (Nielsen-Krug finding #404):
- Adds a **"Download & Install (recommended)"** section at the top of the getting-started area — the no-Python prebuilt installers from Releases — so the easiest path is what a first-time player sees first.
- Reframes the clone/pip/`python src/roam.py` steps as **"Run from Source (for developers)"**.
- Renames the `install.ps1` section to **"Windows setup script (run from source)"** and explicitly distinguishes it from the `RoamSetup.exe` **installer** (resolving the two-things-both-called-"wizard" collision).

Docs-only; internal anchor links verified against the new heading slugs.

## Test plan
- [x] Heading outline reads top-to-bottom: Download & Install → Run from Source → Run Script (Linux) → Windows setup script → Building (advanced) → data location.
- [x] Anchor links (`#download--install-recommended`, `#run-from-source-for-developers`) match the generated slugs.

Closes #404

---
*drafted by Claude on behalf of Daniel Stephenson*