### PR TITLE
ux: install.ps1 — surface install progress/errors and set post-install expectations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ logged in detail below.
 
 | Date | Commits | Summary |
 |------|---------|---------|
+| 2026-06-07 | 1+ | ux: install.ps1 — drop `--quiet` so dependency-install progress is visible (no more "frozen" hang) and pip's real error shows on failure; the completion message now warns that shortcuts are anchored to the folder and prints where saves/settings/screenshots live (`%APPDATA%\Roam`) (closes #400, #401) |
 | 2026-06-07 | 1+ | docs: Lead the README with the recommended prebuilt download (no Python), reframe the clone steps as "Run from Source (for developers)", and rename the `install.ps1` section to a "setup script" distinct from the `RoamSetup.exe` installer — fixes the information scent and the two-things-both-called-"wizard" naming collision (closes #404) |
 | 2026-06-07 | 1+ | test: Add unit-test coverage for `Room.tickExcrement` (spawn/decay/grass-blocking branches), `Inventory.hasAvailableSlotFor` (empty/matching-stack/full), and `MapImageGenerator` coordinate + bounds math; align `test_room.py` entity imports to the production `entity.*` root so `isinstance` checks match room-created entities; +18 tests (issues #372, #367) |
 | 2026-06-07 | 1+ | chore: Bump GitHub Actions to their Node 24 majors across all workflows — `actions/checkout` v4→v6, `actions/setup-python` v5→v6, `actions/upload-artifact` v4→v7 — clearing the Node.js 20 deprecation warnings |

--- a/install.ps1
+++ b/install.ps1
@@ -81,17 +81,20 @@ function Install-Dependencies {
         }
     }
 
-    Write-Host "Installing pygame..."
-    & $Python -m pip install pygame --pre --quiet
+    # Show pip's normal output (no --quiet): the downloads can take a minute, so
+    # the progress reassures the user it isn't frozen, and on failure pip's real
+    # error is visible instead of being swallowed.
+    Write-Host "Installing pygame (this can take a minute)..."
+    & $Python -m pip install pygame --pre
     if ($LASTEXITCODE -ne 0) {
-        Write-Host "Failed to install pygame." -ForegroundColor Red
+        Write-Host "Failed to install pygame. See the pip output above for the cause." -ForegroundColor Red
         return $false
     }
 
     Write-Host "Installing remaining dependencies from requirements.txt..."
-    & $Python -m pip install -r (Join-Path $RepoRoot "requirements.txt") --quiet
+    & $Python -m pip install -r (Join-Path $RepoRoot "requirements.txt")
     if ($LASTEXITCODE -ne 0) {
-        Write-Host "Failed to install requirements.txt dependencies." -ForegroundColor Red
+        Write-Host "Failed to install dependencies. See the pip output above for the cause." -ForegroundColor Red
         return $false
     }
 
@@ -190,6 +193,11 @@ Create-Shortcuts -IconPath $iconPath
 Write-Step "Installation complete"
 Write-Host "Roam is installed. Launch it from the Desktop or Start Menu shortcut," -ForegroundColor Green
 Write-Host "or by double-clicking run.bat in this folder." -ForegroundColor Green
+Write-Host ""
+Write-Host "The shortcuts point to this folder ($RepoRoot), so keep it where it is —"
+Write-Host "moving or deleting it will break them (re-run install.ps1 if you do move it)."
+$dataDir = Join-Path $env:APPDATA "Roam"
+Write-Host "Your saves, settings, and screenshots are stored in: $dataDir"
 
 if ($NonInteractive -or $NoLaunch) {
     Write-Host "Skipping launch (run was non-interactive or -NoLaunch was set)."


### PR DESCRIPTION
## Summary
Two Nielsen-Krug install-wizard findings:
- **#400** — `install.ps1` ran `pip ... --quiet`, so the dependency install hung with no output (looks frozen; Nielsen #1) and, on failure, showed only a generic message while `--quiet` had discarded pip's real error (undiagnosable; Nielsen #9). Now runs pip without `--quiet`, and the failure messages point at the visible pip output.
- **#401** — the completion message said "Roam is installed" but never warned that the shortcuts are anchored to this folder (tidying it up silently breaks them; Nielsen #1) nor where saves live (Nielsen #6). Added two lines: keep this folder put, and data is in `%APPDATA%\Roam`.

## Test plan
- [x] The existing `windows-installer` CI job runs `install.ps1 -NonInteractive` and asserts the shortcuts/icon are produced — exercises these changes on a real Windows runner.
- [ ] Manual: a failing `pip install` now prints the cause; the completion screen shows the folder warning and data path.

Closes #400, #401

---
*drafted by Claude on behalf of Daniel Stephenson*