### PR TITLE
fix: Prevent floor tiles from being placed on existing floors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ logged in detail below.
 
 | Date | Commits | Summary |
 |------|---------|---------|
+| 2026-06-07 | 1+ | fix: Prevent stacking floor tiles — `executePlaceAction` now blocks placing a `WoodFloor`/`StoneFloor` where a floor already exists (via a new `locationContainsFloor` helper), setting "A floor is already here" and consuming no item; +2 tests (closes #345) |
 | 2026-06-07 | 1+ | ux: install.ps1 — drop `--quiet` so dependency-install progress is visible (no more "frozen" hang) and pip's real error shows on failure; the completion message now warns that shortcuts are anchored to the folder and prints where saves/settings/screenshots live (`%APPDATA%\Roam`) (closes #400, #401) |
 | 2026-06-07 | 1+ | docs: Lead the README with the recommended prebuilt download (no Python), reframe the clone steps as "Run from Source (for developers)", and rename the `install.ps1` section to a "setup script" distinct from the `RoamSetup.exe` installer — fixes the information scent and the two-things-both-called-"wizard" naming collision (closes #404) |
 | 2026-06-07 | 1+ | test: Add unit-test coverage for `Room.tickExcrement` (spawn/decay/grass-blocking branches), `Inventory.hasAvailableSlotFor` (empty/matching-stack/full), and `MapImageGenerator` coordinate + bounds math; align `test_room.py` entity imports to the production `entity.*` root so `isinstance` checks match room-created entities; +18 tests (issues #372, #367) |
@@ -88,6 +89,12 @@ logged in detail below.
 | 2022-08-08 | 21 | Create version.txt; Update README.md; Modified README. (+9 more) |
 
 ## AI Agent Sessions
+
+### 2026-06-07 — Prevent floors from being placed on floors (issue #345)
+- **`src/screen/worldScreen.py`:** Floor tiles (`WoodFloor`, `StoneFloor`) are non-solid, so the existing `locationContainsSolidEntity` guard didn't stop them — players could stack multiple floors on one location, wasting items. Added a `locationContainsFloor(location)` helper (mirroring `locationContainsSolidEntity`) and a guard in `executePlaceAction`: when the selected item is a floor and the target already contains a floor, it sets the status `"A floor is already here"` and returns **before** energy or the item is consumed. Imported `WoodFloor`/`StoneFloor`.
+- **`tests/screen/test_worldScreen_placeFloor.py` (new):** Two tests driving `executePlaceAction` via the `WorldScreen.__new__` + mocked-deps harness used by the other worldScreen tests — placing a `StoneFloor` on a location that already has a `WoodFloor` is blocked (no `StoneFloor` added, item not consumed, status set), and placing a floor on an empty location still succeeds (placed + item consumed). The blocked test was confirmed to fail without the guard.
+- **Validation:** `python3 -m compileall src -q` clean; `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` → 513 passed (was 511; +2). The new lines are Black-clean (`black --diff` flags only pre-existing drift elsewhere in `worldScreen.py`, which was intentionally left untouched to keep this PR scoped, per the format-scope lesson).
+- **Learning Log:** `[integrated]` — no new convention; reused the existing scoped-formatting rule (don't run Black tree-wide on a file with pre-existing drift) and the worldScreen test harness pattern.
 
 ### 2026-06-07 — Add unit-test coverage for excrement decay, inventory slotting, and minimap geometry (issues #372, #367)
 - **`tests/world/test_room.py`:** Added eight tests for `Room.tickExcrement`, previously uncovered. Using the room's real 3×3 grid and a `SimpleNamespace(excrementDecayTicks=…)` config stub, they drive each branch: a living entity spawns excrement when `random.randrange` is monkeypatched to hit the 0.1% chance (and does **not** when it misses); an entity at location `-1` is skipped; a bogus location id exercises the `KeyError` guard without crashing; excrement below the decay threshold is left in place; expired excrement on an empty location decays into grass; and grass placement is correctly blocked by an existing `Grass` and by a solid `Stone`.

--- a/src/screen/worldScreen.py
+++ b/src/screen/worldScreen.py
@@ -30,6 +30,8 @@ from lib.graphik.src.graphik import Graphik
 from entity.grass import Grass
 from lib.pyenvlib.grid import Grid
 from entity.stone import Stone
+from entity.woodFloor import WoodFloor
+from entity.stoneFloor import StoneFloor
 from lib.pyenvlib.location import Location
 from world.room import Room
 from world.roomJsonReaderWriter import RoomJsonReaderWriter
@@ -603,6 +605,13 @@ class WorldScreen:
                 return True
         return False
 
+    def locationContainsFloor(self, location):
+        for entityId in list(location.getEntities().keys()):
+            entity = location.getEntity(entityId)
+            if isinstance(entity, (WoodFloor, StoneFloor)):
+                return True
+        return False
+
     def tryPushStone(self, location, direction):
         stoneEntity = None
         for entityId in list(location.getEntities().keys()):
@@ -719,6 +728,11 @@ class WorldScreen:
         selectedItem = inventorySlot.getContents()[0]
         if isinstance(selectedItem, WheatSeed):
             self._plantWheatSeed(targetLocation, targetRoom)
+            return
+
+        isFloor = isinstance(selectedItem, (WoodFloor, StoneFloor))
+        if isFloor and self.locationContainsFloor(targetLocation):
+            self.status.set("A floor is already here")
             return
 
         self.player.removeEnergy(self.config.playerInteractionEnergyCost)

--- a/tests/screen/test_worldScreen_placeFloor.py
+++ b/tests/screen/test_worldScreen_placeFloor.py
@@ -1,0 +1,87 @@
+import os
+
+os.environ["SDL_VIDEODRIVER"] = "dummy"
+os.environ["SDL_AUDIODRIVER"] = "dummy"
+import pygame
+import pytest
+from unittest.mock import MagicMock
+
+from entity.woodFloor import WoodFloor
+from entity.stoneFloor import StoneFloor
+from inventory.inventory import Inventory
+from world.room import Room
+
+
+@pytest.fixture(scope="module", autouse=True)
+def init_pygame():
+    pygame.init()
+    yield
+    pygame.quit()
+
+
+def createWorldScreen():
+    from config.config import Config
+    from screen.worldScreen import WorldScreen
+
+    config = Config()
+    pygame.display.set_mode((800, 600))
+    ws = WorldScreen.__new__(WorldScreen)
+    ws.config = config
+    ws.status = MagicMock()
+    ws.tickCounter = MagicMock()
+    ws.isLocationTooFar = MagicMock(return_value=False)
+    return ws
+
+
+def createRoom(gridSize=3):
+    return Room("test", gridSize, (0, 0, 0), 0, 0, MagicMock())
+
+
+def _floorCounts(location):
+    counts = {"WoodFloor": 0, "StoneFloor": 0}
+    for entityId in list(location.getEntities().keys()):
+        name = type(location.getEntity(entityId)).__name__
+        if name in counts:
+            counts[name] += 1
+    return counts
+
+
+def _placeFloorAt(selectedFloor, location, room):
+    ws = createWorldScreen()
+    ws.currentRoom = room
+
+    player = MagicMock()
+    inventory = Inventory()
+    inventory.placeIntoFirstAvailableInventorySlot(selectedFloor)
+    player.getInventory.return_value = inventory
+    ws.player = player
+
+    ws.getLocationAndRoomAtMousePosition = MagicMock(return_value=(location, room))
+    ws.executePlaceAction()
+    return ws, inventory
+
+
+def test_placing_floor_on_existing_floor_is_blocked():
+    room = createRoom()
+    location = room.getGrid().getLocationByCoordinates(1, 1)
+    room.addEntityToLocation(WoodFloor(), location)  # a floor is already here
+
+    ws, inventory = _placeFloorAt(StoneFloor(), location, room)
+
+    # The StoneFloor was not added; only the original WoodFloor remains.
+    assert _floorCounts(location) == {"WoodFloor": 1, "StoneFloor": 0}
+    # The item was not consumed.
+    assert inventory.getNumTakenInventorySlots() == 1
+    ws.status.set.assert_called_with("A floor is already here")
+
+
+def test_placing_floor_on_empty_location_succeeds():
+    room = createRoom()
+    location = room.getGrid().getLocationByCoordinates(1, 1)
+
+    ws, inventory = _placeFloorAt(WoodFloor(), location, room)
+
+    # The WoodFloor was placed and the item consumed.
+    assert _floorCounts(location) == {"WoodFloor": 1, "StoneFloor": 0}
+    assert inventory.getNumTakenInventorySlots() == 0
+    ws.status.set.assert_called_with("Placed Wood Floor")


### PR DESCRIPTION
## Summary
`WoodFloor`/`StoneFloor` are non-solid, so `executePlaceAction`'s `locationContainsSolidEntity` guard never blocked them — players could stack multiple floor tiles on one location, silently wasting inventory items (issue #345).

- Adds a `locationContainsFloor(location)` helper (mirroring `locationContainsSolidEntity`).
- Guards `executePlaceAction`: if the selected item is a floor and the target already contains a floor, set `"A floor is already here"` and return **before** any energy or item is consumed.

## Test plan
- [x] `tests/screen/test_worldScreen_placeFloor.py` (new): placing a `StoneFloor` on an existing `WoodFloor` is blocked (no floor added, item not consumed, status set); placing on an empty location still succeeds. The blocked test **fails without the guard** (verified by stashing the change).
- [x] `pytest` → 513 passed (+2).
- Note: `black --diff` reports only pre-existing drift elsewhere in `worldScreen.py`; the added lines are Black-clean and the drift was left untouched to keep this PR scoped.

Closes #345

---
*drafted by Claude on behalf of Daniel Stephenson*