### PR TITLE
refactor: Data-driven hotbar key dispatch in InventoryScreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ logged in detail below.
 
 | Date | Commits | Summary |
 |------|---------|---------|
+| 2026-06-07 | 1+ | refactor: Replace the 10 near-identical hotbar `elif` branches in `InventoryScreen.handleKeyDownEvent` with a data-driven `_handleHotbarKey` loop (preserving the `hotbar_0 → slot 9` wrap); +3 tests (closes #410) |
 | 2026-06-07 | 1+ | fix: Correct release versioning — `version.txt` had been stale at `0.8.0-SNAPSHOT` while `0.9.0`/`0.10.0` were already released, leading to an erroneous `v0.9.0` tag/release (now deleted); set `version.txt` to `0.11.0-SNAPSHOT`, switch the release workflow to the repo's bare-number tag convention (`0.11.0`, not `v0.11.0`), and fix `UpdateChecker` to read the `/releases` list (every Roam release is a GitHub pre-release, so `/releases/latest` 404s) |
 | 2026-06-07 | 1+ | feat: In-game update notifier + version plumbing — bundle `version.txt` in `roam.spec` and stamp the release tag into it (so packaged builds know their version, previously blank), add `Config.getVersion()`, and add an `UpdateChecker` that checks GitHub Releases on a daemon thread (fail-silent, `checkForUpdates` config toggle) and shows a "press U to download" banner on the main menu (closes #413, #414) |
 | 2026-06-07 | 1+ | fix: Prevent stacking floor tiles — `executePlaceAction` now blocks placing a `WoodFloor`/`StoneFloor` where a floor already exists (via a new `locationContainsFloor` helper), setting "A floor is already here" and consuming no item; +2 tests (closes #345) |

--- a/src/screen/inventoryScreen.py
+++ b/src/screen/inventoryScreen.py
@@ -72,26 +72,17 @@ class InventoryScreen:
             self.switchToWorldScreen()
         elif key == kb.getKey("screenshot"):
             takeScreenshot(self.graphik.getGameDisplay())
-        elif key == kb.getKey("hotbar_1"):
-            self.swapCursorSlotWithInventorySlotByIndex(0)
-        elif key == kb.getKey("hotbar_2"):
-            self.swapCursorSlotWithInventorySlotByIndex(1)
-        elif key == kb.getKey("hotbar_3"):
-            self.swapCursorSlotWithInventorySlotByIndex(2)
-        elif key == kb.getKey("hotbar_4"):
-            self.swapCursorSlotWithInventorySlotByIndex(3)
-        elif key == kb.getKey("hotbar_5"):
-            self.swapCursorSlotWithInventorySlotByIndex(4)
-        elif key == kb.getKey("hotbar_6"):
-            self.swapCursorSlotWithInventorySlotByIndex(5)
-        elif key == kb.getKey("hotbar_7"):
-            self.swapCursorSlotWithInventorySlotByIndex(6)
-        elif key == kb.getKey("hotbar_8"):
-            self.swapCursorSlotWithInventorySlotByIndex(7)
-        elif key == kb.getKey("hotbar_9"):
-            self.swapCursorSlotWithInventorySlotByIndex(8)
-        elif key == kb.getKey("hotbar_0"):
-            self.swapCursorSlotWithInventorySlotByIndex(9)
+        else:
+            self._handleHotbarKey(key)
+
+    def _handleHotbarKey(self, key):
+        # hotbar_1..hotbar_9 select inventory slots 0..8 and hotbar_0 selects
+        # slot 9 (the "10th" hotbar key wraps to index 9).
+        kb = self.keyBindings
+        for index in range(10):
+            if key == kb.getKey("hotbar_" + str((index + 1) % 10)):
+                self.swapCursorSlotWithInventorySlotByIndex(index)
+                return
 
     def switchToWorldScreen(self):
         self.nextScreen = ScreenType.WORLD_SCREEN

--- a/tests/screen/test_inventoryScreen.py
+++ b/tests/screen/test_inventoryScreen.py
@@ -1,0 +1,56 @@
+import os
+
+os.environ["SDL_VIDEODRIVER"] = "dummy"
+os.environ["SDL_AUDIODRIVER"] = "dummy"
+from unittest.mock import MagicMock
+
+from screen.inventoryScreen import InventoryScreen
+
+
+def _screen():
+    # Bypass the DI constructor; wire only what the hotbar dispatch needs.
+    # getKey returns the binding name itself, so a "key" can be the name string.
+    screen = InventoryScreen.__new__(InventoryScreen)
+    screen.craftPanelOpen = False
+    screen.keyBindings = MagicMock()
+    screen.keyBindings.getKey = lambda name: name
+    screen._swapCalls = []
+    screen.swapCursorSlotWithInventorySlotByIndex = screen._swapCalls.append
+    return screen
+
+
+def test_hotbar_keys_map_to_correct_slots():
+    screen = _screen()
+    expected = {
+        "hotbar_1": 0,
+        "hotbar_2": 1,
+        "hotbar_3": 2,
+        "hotbar_4": 3,
+        "hotbar_5": 4,
+        "hotbar_6": 5,
+        "hotbar_7": 6,
+        "hotbar_8": 7,
+        "hotbar_9": 8,
+        # hotbar_0 wraps to slot 9 — the subtlety the refactor must preserve.
+        "hotbar_0": 9,
+    }
+    for name, index in expected.items():
+        screen._swapCalls.clear()
+        screen._handleHotbarKey(name)
+        assert screen._swapCalls == [index], name
+
+
+def test_non_hotbar_key_is_ignored():
+    screen = _screen()
+    screen._handleHotbarKey("some_other_key")
+    assert screen._swapCalls == []
+
+
+def test_handle_key_down_routes_hotbar_key_to_slot():
+    # The else-branch of handleKeyDownEvent dispatches to the hotbar handler.
+    screen = _screen()
+    screen._handleHotbarKey("hotbar_3")
+    assert screen._swapCalls == [2]
+    screen._swapCalls.clear()
+    screen.handleKeyDownEvent("hotbar_5")
+    assert screen._swapCalls == [4]


### PR DESCRIPTION
## Summary
`InventoryScreen.handleKeyDownEvent` dispatched the ten hotbar keys with ten near-identical `elif` branches (`hotbar_1`..`hotbar_0` → slots `0`..`9`) — ten lines differing only by two numbers, where an off-by-one is easy to introduce and hard to spot. Replaced with a `_handleHotbarKey(key)` loop that preserves the `hotbar_0 → slot 9` wrap.

## Test plan
- [x] New `tests/screen/test_inventoryScreen.py` pins the full mapping including the `hotbar_0 → 9` wrap, the non-hotbar no-op, and that `handleKeyDownEvent` routes a hotbar key through the new handler. `pytest` → 535 passed (+3).
- [x] Black-clean (the two `inventoryScreen.py` blocks Black flags are pre-existing drift elsewhere in the file, left untouched to keep this PR scoped).

## Deferred this cycle (skip reasons)
The other open refactors (#409 rooms-dir, #411 schema caching, #412 minimap log) and #364 (persistence tests) are left for future cycles. Do-not-auto-merge issues (#362 copilot-instructions, #365 config.yml, #370 save serializers) and cert-blocked ones (#393/#396) are best landed individually with review; larger features (#346/#338/#239/#234/#231, #415/#416) and install-UX (#399/#402/#403/#405) are out of scope here.

Closes #410

---
*drafted by Claude on behalf of Daniel Stephenson*