### PR TITLE
refactor: Single source of truth for the rooms save directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ logged in detail below.
 
 | Date | Commits | Summary |
 |------|---------|---------|
+| 2026-06-07 | 1+ | refactor: Add `Config.getRoomsDirectory()` as the single source of truth for the `<saveDir>/rooms` path — `getRoomFilePath` and both makedirs sites (`roomJsonReaderWriter`, `worldScreenPersistence`) now go through it instead of hand-concatenating `"/rooms"` (closes #409) |
 | 2026-06-07 | 1+ | refactor: Replace the 10 near-identical hotbar `elif` branches in `InventoryScreen.handleKeyDownEvent` with a data-driven `_handleHotbarKey` loop (preserving the `hotbar_0 → slot 9` wrap); +3 tests (closes #410) |
 | 2026-06-07 | 1+ | fix: Correct release versioning — `version.txt` had been stale at `0.8.0-SNAPSHOT` while `0.9.0`/`0.10.0` were already released, leading to an erroneous `v0.9.0` tag/release (now deleted); set `version.txt` to `0.11.0-SNAPSHOT`, switch the release workflow to the repo's bare-number tag convention (`0.11.0`, not `v0.11.0`), and fix `UpdateChecker` to read the `/releases` list (every Roam release is a GitHub pre-release, so `/releases/latest` 404s) |
 | 2026-06-07 | 1+ | feat: In-game update notifier + version plumbing — bundle `version.txt` in `roam.spec` and stamp the release tag into it (so packaged builds know their version, previously blank), add `Config.getVersion()`, and add an `UpdateChecker` that checks GitHub Releases on a daemon thread (fail-silent, `checkForUpdates` config toggle) and shows a "press U to download" banner on the main menu (closes #413, #414) |

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -321,12 +321,15 @@ class Config:
             debug=self.debug,
         )
 
+    def getRoomsDirectory(self):
+        """Return the directory holding per-room JSON files: the single source
+        of truth for the `<saveDir>/rooms` location."""
+        return self.pathToSaveDirectory + "/rooms"
+
     def getRoomFilePath(self, x, y):
-        """Return the path to a room's JSON save file: the single source of
-        truth for the on-disk room-file layout."""
-        return (
-            self.pathToSaveDirectory + "/rooms/room_" + str(x) + "_" + str(y) + ".json"
-        )
+        """Return the path to a room's JSON save file, built on top of
+        getRoomsDirectory so the `/rooms` layout lives in one place."""
+        return self.getRoomsDirectory() + "/room_" + str(x) + "_" + str(y) + ".json"
 
     def _writeKeyValues(self, savedValues, errorMessage):
         configFilePath = self.getConfigFilePath()

--- a/src/screen/worldScreenPersistence.py
+++ b/src/screen/worldScreenPersistence.py
@@ -131,8 +131,7 @@ class WorldScreenPersistence:
     def saveRoomToFile(self, room):
         roomPath = self.config.getRoomFilePath(room.getX(), room.getY())
         _logger.info("saving room", path=roomPath)
-        if not os.path.exists(self.config.pathToSaveDirectory + "/rooms"):
-            os.makedirs(self.config.pathToSaveDirectory + "/rooms")
+        os.makedirs(self.config.getRoomsDirectory(), exist_ok=True)
 
         jsonRoom = self.roomJsonReaderWriter.generateJsonForRoom(room)
         with open(roomPath, "w") as outfile:

--- a/src/world/roomJsonReaderWriter.py
+++ b/src/world/roomJsonReaderWriter.py
@@ -80,8 +80,7 @@ class RoomJsonReaderWriter:
     def saveRoom(self, room, path):
         _logger.info("saving room", path=path, roomX=room.getX(), roomY=room.getY())
         roomJson = self.generateJsonForRoom(room)
-        if not os.path.exists(self.config.pathToSaveDirectory + "/rooms"):
-            os.makedirs(self.config.pathToSaveDirectory + "/rooms")
+        os.makedirs(self.config.getRoomsDirectory(), exist_ok=True)
         with open(path, "w") as outfile:
             json.dump(roomJson, outfile, indent=4)
 

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -403,6 +403,13 @@ def test_write_key_values_updates_appends_and_preserves(tmp_path, monkeypatch):
     assert "# a comment" in content
 
 
+def test_get_rooms_directory_format():
+    config = Config()
+    config.pathToSaveDirectory = "saves/myworld"
+    # Single source of truth for the <saveDir>/rooms directory.
+    assert config.getRoomsDirectory() == "saves/myworld/rooms"
+
+
 def test_get_room_file_path_format():
     config = Config()
     config.pathToSaveDirectory = "saves/myworld"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ def test_config(tmp_path):
     config.ticksPerSecond = 30
     # Delegate to the real implementation so room-path construction reflects
     # the (possibly per-test overridden) pathToSaveDirectory.
+    config.getRoomsDirectory = lambda: Config.getRoomsDirectory(config)
     config.getRoomFilePath = lambda x, y: Config.getRoomFilePath(config, x, y)
     return config
 


### PR DESCRIPTION
## Summary
The `<saveDir>/rooms` path was hand-concatenated in three places — `Config.getRoomFilePath` and the `os.makedirs` in `roomJsonReaderWriter.saveRoom` and `worldScreenPersistence.saveRoomToFile` — so the `"/rooms"` literal could drift independently (the gap #409 names, and a follow-on to #373 which had only consolidated the room *file* path).

- Adds `Config.getRoomsDirectory()` → `<saveDir>/rooms`.
- `getRoomFilePath` is built on top of it; both makedirs sites now call `os.makedirs(self.config.getRoomsDirectory(), exist_ok=True)`.
- **The serialized save format is unchanged** — this only touches where the directory path is built / created, not what is written.

## Test plan
- [x] `pytest` → 536 passed. Added `test_get_rooms_directory_format`; the existing `test_get_room_file_path_format` still pins the same on-disk layout (now produced via `getRoomsDirectory`).
- [x] Delegated `getRoomsDirectory` on the shared `test_config` `MagicMock(spec=Config)` (the spec-mock hazard, roam-dev-loop#4) — without it, `saveRoom` got a MagicMock and 9 room tests failed; verified green after.
- [x] Black-clean on the changed lines (pre-existing drift elsewhere in `test_config.py` left untouched, per the scoped-formatting convention).

## Deferred this cycle (skip reasons)
Other refactors (#411 schema caching, #412 minimap log) and #364 (persistence tests) left for future cycles; do-not-auto-merge issues (#362/#365/#370) and cert-blocked (#393/#396) for manual review; larger features and install-UX out of scope.

Closes #409

---
*drafted by Claude on behalf of Daniel Stephenson*