### PR TITLE
docs: sync config.yml and copilot-instructions with the code

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,10 +8,10 @@ Roam is a single-player 2D survival game built with Python and Pygame. Players e
 - **Game framework:** Pygame 2.1.2
 - **Testing:** pytest 7.1.3, pytest-cov 4.0.0
 - **Formatter:** Black (via `format.sh`), autoflake (unused import/variable removal)
-- **Image processing:** Pillow 9.4.0
+- **Image processing:** Pillow >=10.0.0
 - **JSON schema validation:** jsonschema 4.17.3
 - **Bundled libraries:** [graphik](https://github.com/Preponderous-Software/graphik) (vendored in `src/lib/graphik`), [py_env_lib](https://github.com/Preponderous-Software/py_env_lib) (vendored in `src/lib/pyenvlib`)
-- **Version:** 0.8.0-SNAPSHOT (tracked in `version.txt`)
+- **Version:** 0.11.0-SNAPSHOT (tracked in `version.txt`)
 
 ## Repository Layout
 
@@ -22,10 +22,13 @@ Roam is a single-player 2D survival game built with Python and Pygame. Players e
   - `inventory/` — Inventory system and JSON persistence.
   - `player/` — Player class.
   - `world/` — World map, rooms, room generation, tick counter.
+  - `crafting/` — Crafting recipes and the recipe registry (`recipe.py`, `recipeRegistry.py`).
+  - `codex/` — Discovered-entity codex and its JSON persistence (`codex.py`, `codexJsonReaderWriter.py`).
   - `screen/` — Game screens (main menu, world, options, inventory, stats, config).
   - `ui/` — HUD elements (energy bar, status display).
   - `stats/` — Game statistics tracking.
   - `mapimage/` — Map image generation and updating.
+  - `gameLogging/` — Structured logging helpers (`logger.py` — `getLogger()`, `redact()`).
   - `di/` — Lightweight dependency injection container (stdlib-only).
   - `appContainer.py` — Module-level container singleton and `component` decorator.
   - `bootstrap.py` — Centralized factory/instance registrations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ logged in detail below.
 
 | Date | Commits | Summary |
 |------|---------|---------|
+| 2026-06-07 | 1+ | docs: Sync the config/docs sources of truth — drop the dead `black`/`white` keys from `config.yml` and add the missing `cropGrowthTicks` (static) and `pushableStone` (dynamic toggle) keys the code already reads; correct `copilot-instructions.md` (add the `crafting/`, `codex/`, `gameLogging/` packages to the repository layout, fix the Pillow version to `>=10.0.0`, refresh the stale `0.8.0-SNAPSHOT` version marker to `0.11.0-SNAPSHOT`) (closes #362, #365) |
 | 2026-06-07 | 1+ | refactor: Add `Config.getRoomsDirectory()` as the single source of truth for the `<saveDir>/rooms` path — `getRoomFilePath` and both makedirs sites (`roomJsonReaderWriter`, `worldScreenPersistence`) now go through it instead of hand-concatenating `"/rooms"` (closes #409) |
 | 2026-06-07 | 1+ | refactor: Replace the 10 near-identical hotbar `elif` branches in `InventoryScreen.handleKeyDownEvent` with a data-driven `_handleHotbarKey` loop (preserving the `hotbar_0 → slot 9` wrap); +3 tests (closes #410) |
 | 2026-06-07 | 1+ | fix: Correct release versioning — `version.txt` had been stale at `0.8.0-SNAPSHOT` while `0.9.0`/`0.10.0` were already released, leading to an erroneous `v0.9.0` tag/release (now deleted); set `version.txt` to `0.11.0-SNAPSHOT`, switch the release workflow to the repo's bare-number tag convention (`0.11.0`, not `v0.11.0`), and fix `UpdateChecker` to read the `/releases` list (every Roam release is a GitHub pre-release, so `/releases/latest` 404s) |
@@ -93,6 +94,14 @@ logged in detail below.
 | 2022-08-08 | 21 | Create version.txt; Update README.md; Modified README. (+9 more) |
 
 ## AI Agent Sessions
+
+### 2026-06-07 — Sync the config and copilot-instructions sources of truth (issues #362, #365)
+- **Context:** A triage pass found drift between three sources of truth and the code: `config.yml`, `.github/copilot-instructions.md`, and `version.txt`. Each claim was re-verified against source before editing (line numbers in the issues were stale but the underlying mismatches held).
+- **`config.yml` (#365):** Removed the `black`/`white` keys — they parse into `Config.black`/`Config.white` but a grep across `src/` (excluding `src/lib/`) finds zero consumers, so they were dead and misleading. Added the two keys the code reads but the file omitted: `cropGrowthTicks: 1800` (read at `config.py`, consumed at `world/room.py` for crop maturity) under the static section, and `pushableStone: true` (read at `config.py`, consumed at `worldScreen.py`, and already an in-game toggle in `configScreen.py`) under the dynamic section. The `getColorValue` helper and `Config.black`/`Config.white` reads were left in place — they default harmlessly and are covered by `tests/config/test_config.py`; removing them would delete tested code, which the issue marks as optional and is out of scope for a config-sync change.
+- **`.github/copilot-instructions.md` (#362):** Added the `crafting/`, `codex/`, and `gameLogging/` packages (all present under `src/`) to the Repository Layout; corrected the Pillow version from the stale `9.4.0` to `>=10.0.0` to match `requirements.txt` (the issue said `==12.2.0`, but the actual pin is `>=10.0.0`); refreshed the stale `0.8.0-SNAPSHOT` version marker in the Technology Stack section to `0.11.0-SNAPSHOT` to match `version.txt`.
+- **Validation:** `python3 -m compileall src -q` clean; `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` green (config/docs-only change; no behavioral code touched).
+- **Merge note:** `config.yml` is on the do-not-auto-merge list, so this PR is left for manual review rather than auto-merged.
+- **Learning Log:** `[integrated]` — no new convention; reinforces the existing doc-drift / config-sync triage rules already in `copilot-instructions.md`. Confirmed the standing lesson that issue-reported specifics (line numbers, the `==12.2.0` Pillow pin) must be re-verified against source — Phase-3 localization caught the wrong version string before it shipped.
 
 ### 2026-06-07 — Correct release versioning and the update-check endpoint
 - **Context:** `version.txt` had drifted to `0.8.0-SNAPSHOT` while the repo had in fact already published `0.9.0` and `0.10.0` (all releases are GitHub pre-releases, bare-number tags). Trusting the stale file, an erroneous `v0.9.0` tag + release was cut today (a duplicate version, `v`-prefixed against the bare-number convention, and briefly flagged "latest"). It was deleted (the real `0.9.0`/`0.10.0` are separate tags and untouched).

--- a/config.yml
+++ b/config.yml
@@ -4,8 +4,6 @@
 # displayWidth/displayHeight default to 90% of display height when omitted.
 # displayWidth: 972
 # displayHeight: 972
-black: [0, 0, 0]
-white: [255, 255, 255]
 playerMovementEnergyCost: 0.2
 playerInteractionEnergyCost: 0.05
 runSpeedFactor: 2
@@ -15,6 +13,8 @@ ticksPerSecond: 30
 gridSize: 17
 worldBorder: 0
 excrementDecayTicks: 3600
+# Ticks for a planted crop to grow to maturity (30 tps → 1800 ticks ≈ 60s).
+cropGrowthTicks: 1800
 # pathToSaveDirectory: leave unset to use the platform default save location
 # ("saves/defaultsavefile", or %APPDATA%\Roam\saves\defaultsavefile on Windows).
 # Set it explicitly to override, e.g. pathToSaveDirectory: saves/defaultsavefile
@@ -27,6 +27,7 @@ removeDeadEntities: true
 showMiniMap: true
 cameraFollowPlayer: true
 limitTps: true
+pushableStone: true
 dayNightCycleEnabled: true
 dayNightCycleLengthTicks: 54000
 # Check GitHub for a newer release on launch and show a notice on the main menu.


### PR DESCRIPTION
## Summary

Two sources-of-truth drift issues found during triage, fixed together as a documentation/config sync. Every claim was re-verified against source before editing.

**`config.yml` (#365)**
- Removed the dead `black` / `white` keys — they parse into `Config.black` / `Config.white`, but a grep across `src/` (excluding `src/lib/`) finds zero consumers. The places needing those colors use hardcoded literals.
- Added `cropGrowthTicks: 1800` (static) — read at `config.py`, consumed at `world/room.py:301` for crop maturity.
- Added `pushableStone: true` (dynamic) — read at `config.py`, consumed at `worldScreen.py:432`, and already an in-game toggle at `configScreen.py:66`, yet the only such toggle missing from the file.

**`.github/copilot-instructions.md` (#362)**
- Added the `crafting/`, `codex/`, and `gameLogging/` packages (all present under `src/`) to the Repository Layout.
- Corrected the Pillow version `9.4.0` → `>=10.0.0` to match `requirements.txt`. (The issue said `==12.2.0`; the actual pin is `>=10.0.0` — corrected to reality.)
- Refreshed the stale `0.8.0-SNAPSHOT` version marker → `0.11.0-SNAPSHOT` to match `version.txt`.

**`CHANGELOG.md`** — dated summary-table row + detailed AI Agent Sessions entry (`[integrated]`).

## Scope note

The dead `Config.black` / `Config.white` reads and the `getColorValue` helper were left in `config.py`. They default harmlessly and are covered by `tests/config/test_config.py`; removing them would delete tested code, which #365 marks as optional and is out of scope for a config-file sync. Recorded as a carryover.

## Test plan

- [x] `python3 -m compileall src -q` — clean
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — 536 passed
- [x] No `.py` source changed → `format.sh` (Black/autoflake) intentionally not run to avoid pulling in unrelated drift

## Merge note

`config.yml` is on this loop's do-not-auto-merge list, so this PR is for **manual review** — it will not be auto-merged.

## Issues skipped this cycle (recorded for auditability)

- **#416 / #415** (Tier 2/3 update install/auto-updater) — feature work, gated on code-signing (#393/#396); too large for this cycle.
- **#412** (minimap image-load failure swallowed) — valid small fix; deferred to keep this PR a pure config/docs sync.
- **#411** (JSON schema re-read per save/load) — refactor; separate subsystem.
- **#405 / #403 / #402 / #399 / #396 / #393** (installer/packaging/signing) — platform tooling outside the test harness; not doc-drift.
- **#370** (corrupt save crashes load) — bug fix; warrants its own PR with regression tests.
- **#364** (WorldScreenPersistence tests) — test-coverage task; separate scope.
- **#346 / #338 / #239 / #234 / #231** — larger feature requests.

Closes #362
Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_