### PR TITLE
fix: log minimap image-load failures instead of swallowing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ logged in detail below.
 
 | Date | Commits | Summary |
 |------|---------|---------|
+| 2026-06-07 | 1+ | robustness: Log once when the minimap image fails to load — the `except (FileNotFoundError, pygame.error)` in `WorldScreen.drawMiniMap` previously swallowed the failure silently; it now warns via the structured logger on the good->failed transition (throttled by a `_miniMapLoadFailed` flag, reset on a successful load), keeping the existing fallback-to-cached-or-return behavior; +3 tests (closes #412) |
 | 2026-06-07 | 1+ | docs: Sync the config/docs sources of truth — drop the dead `black`/`white` keys from `config.yml` and add the missing `cropGrowthTicks` (static) and `pushableStone` (dynamic toggle) keys the code already reads; correct `copilot-instructions.md` (add the `crafting/`, `codex/`, `gameLogging/` packages to the repository layout, fix the Pillow version to `>=10.0.0`, refresh the stale `0.8.0-SNAPSHOT` version marker to `0.11.0-SNAPSHOT`) (closes #362, #365) |
 | 2026-06-07 | 1+ | refactor: Add `Config.getRoomsDirectory()` as the single source of truth for the `<saveDir>/rooms` path — `getRoomFilePath` and both makedirs sites (`roomJsonReaderWriter`, `worldScreenPersistence`) now go through it instead of hand-concatenating `"/rooms"` (closes #409) |
 | 2026-06-07 | 1+ | refactor: Replace the 10 near-identical hotbar `elif` branches in `InventoryScreen.handleKeyDownEvent` with a data-driven `_handleHotbarKey` loop (preserving the `hotbar_0 → slot 9` wrap); +3 tests (closes #410) |
@@ -94,6 +95,13 @@ logged in detail below.
 | 2022-08-08 | 21 | Create version.txt; Update README.md; Modified README. (+9 more) |
 
 ## AI Agent Sessions
+
+### 2026-06-07 — Log minimap image-load failures instead of swallowing them (issue #412)
+- **Context:** In `WorldScreen.drawMiniMap`, the reload path caught `(FileNotFoundError, pygame.error)` and silently fell back to the cached frame (or returned). The fallback is correct — it must not crash the render loop — but it logged nothing, so a persistently missing/corrupt `mapImage.png` made the minimap silently never appear with zero diagnostic. Same class of silent-render-failure that #368 fixed for `DrawableEntity.getImage`.
+- **`src/screen/worldScreen.py`:** Added a `_miniMapLoadFailed` flag (initialized in `__init__`). The `except` now logs `_logger.warning("could not load minimap image; keeping last good frame if available", path=..., error=...)` only on the good->failed transition (guarded by the flag), and a successful load resets the flag. This avoids per-reload log spam (the path runs every ~60 ticks) while making the failure diagnosable, and re-arms the warning if the minimap recovers and later breaks again. Existing fallback-to-cached-or-return behavior is unchanged.
+- **`tests/screen/test_worldScreen_minimap.py` (new):** 3 tests — a corrupt `mapImage.png` is logged once and `drawMiniMap` returns cleanly (would fail before the fix, which logged nothing); repeated failures log only once (throttle); a successful load resets the failure flag (recovery). Built via `WorldScreen.__new__` with minimal attributes, mirroring `test_worldScreen_saveSurfacing.py`.
+- **Validation:** `python3 -m compileall src -q` clean; `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` → 539 passed (was 536; +3). Black/autoflake scoped to the two changed files; pre-existing Black drift the file-scoped format pulled in (unrelated `status.set`/`_loadOrGenerateRoom` lines) was reverted so the diff carries only the change.
+- **Learning Log:** `[integrated]` — reused the #368 silent-render-failure precedent (structured `getLogger`, log-once degradation) and the cycle-2/4 hunk-scoping rule (roam-dev-loop#3): file-scoped `black` reformatted pre-existing-drift blocks in `worldScreen.py`; those were reverted and only the intended hunks kept.
 
 ### 2026-06-07 — Sync the config and copilot-instructions sources of truth (issues #362, #365)
 - **Context:** A triage pass found drift between three sources of truth and the code: `config.yml`, `.github/copilot-instructions.md`, and `version.txt`. Each claim was re-verified against source before editing (line numbers in the issues were stale but the underlying mismatches held).

--- a/src/screen/worldScreen.py
+++ b/src/screen/worldScreen.py
@@ -108,6 +108,9 @@ class WorldScreen:
         self.minimapY = 5
         self._cachedMiniMapImage = None
         self._miniMapLastLoadTick = 0
+        # Tracks whether the last minimap-image load failed, so the failure is
+        # logged once on the good->failed transition rather than every reload.
+        self._miniMapLoadFailed = False
         self._saveExecutor = ThreadPoolExecutor(
             max_workers=1
         )  # serialize save operations off main thread
@@ -1114,7 +1117,19 @@ class WorldScreen:
                     mapImage = pygame.image.load(mapImagePath)
                     self._cachedMiniMapImage = mapImage
                     self._miniMapLastLoadTick = currentTick
-                except (FileNotFoundError, pygame.error):
+                    self._miniMapLoadFailed = False
+                except (FileNotFoundError, pygame.error) as e:
+                    # Log once on the good->failed transition so a persistently
+                    # missing/corrupt mapImage.png is diagnosable, without
+                    # spamming a log line on every 60-tick reload attempt.
+                    if not self._miniMapLoadFailed:
+                        _logger.warning(
+                            "could not load minimap image; "
+                            "keeping last good frame if available",
+                            path=mapImagePath,
+                            error=str(e),
+                        )
+                        self._miniMapLoadFailed = True
                     if self._cachedMiniMapImage is not None:
                         mapImage = self._cachedMiniMapImage
                     else:

--- a/tests/screen/test_worldScreen_minimap.py
+++ b/tests/screen/test_worldScreen_minimap.py
@@ -1,0 +1,87 @@
+import os
+
+os.environ["SDL_VIDEODRIVER"] = "dummy"
+os.environ["SDL_AUDIODRIVER"] = "dummy"
+
+from unittest.mock import MagicMock
+
+import pygame
+
+
+def _makeWorldScreen(test_config, tmp_path):
+    from screen.worldScreen import WorldScreen
+
+    test_config.pathToSaveDirectory = str(tmp_path)
+    ws = WorldScreen.__new__(WorldScreen)
+    ws.config = test_config
+    ws._cachedMiniMapImage = None
+    ws._miniMapLastLoadTick = 0
+    ws._miniMapLoadFailed = False
+    ws.tickCounter = MagicMock()
+    ws.tickCounter.getTick.return_value = 100  # >= 60 so a reload is due
+    return ws
+
+
+def _writeCorruptMiniMap(tmp_path):
+    (tmp_path / "mapImage.png").write_text("this is not a valid png")
+
+
+def test_corrupt_minimap_image_is_logged_and_does_not_crash(
+    test_config, tmp_path, monkeypatch
+):
+    ws = _makeWorldScreen(test_config, tmp_path)
+    _writeCorruptMiniMap(tmp_path)
+
+    mockLogger = MagicMock()
+    monkeypatch.setattr("screen.worldScreen._logger", mockLogger)
+
+    # No cached frame -> the method must return cleanly (not raise) and record
+    # the failure exactly once (the bug was that this was swallowed silently).
+    result = ws.drawMiniMap()
+
+    assert result is None
+    assert ws._miniMapLoadFailed is True
+    mockLogger.warning.assert_called_once()
+    assert mockLogger.warning.call_args.kwargs["path"].endswith("mapImage.png")
+
+
+def test_repeated_minimap_load_failure_logs_only_once(
+    test_config, tmp_path, monkeypatch
+):
+    ws = _makeWorldScreen(test_config, tmp_path)
+    _writeCorruptMiniMap(tmp_path)
+
+    mockLogger = MagicMock()
+    monkeypatch.setattr("screen.worldScreen._logger", mockLogger)
+
+    ws.drawMiniMap()
+    ws.drawMiniMap()  # second reload still fails, but must not re-log
+
+    assert mockLogger.warning.call_count == 1
+
+
+def test_successful_load_resets_failure_flag(test_config, tmp_path, monkeypatch):
+    ws = _makeWorldScreen(test_config, tmp_path)
+    ws._miniMapLoadFailed = True  # simulate a prior failure streak
+
+    # Write a genuinely loadable image so pygame.image.load succeeds.
+    surface = pygame.Surface((4, 4))
+    pygame.image.save(surface, str(tmp_path / "mapImage.png"))
+
+    # Stub the post-load drawing so the test stays focused on the flag lifecycle.
+    monkeypatch.setattr(
+        pygame.transform,
+        "scale",
+        lambda image, size: MagicMock(get_width=lambda: 10, get_height=lambda: 10),
+    )
+    ws.minimapScaleFactor = 0.2
+    ws.minimapX = 5
+    ws.minimapY = 5
+    ws.graphik = MagicMock()
+    ws.graphik.getGameAreaRect.return_value = MagicMock(width=100)
+    ws.hudDragManager = MagicMock()
+    ws.hudDragManager.getOffset.return_value = (0, 0)
+
+    ws.drawMiniMap()
+
+    assert ws._miniMapLoadFailed is False


### PR DESCRIPTION
## Summary

In `WorldScreen.drawMiniMap`, the minimap reload path caught `(FileNotFoundError, pygame.error)` and silently fell back to the cached frame (or returned). The fallback is correct — it must not crash the render loop — but it logged **nothing**, so a persistently missing or corrupt `mapImage.png` made the minimap silently never appear with zero diagnostic. This is the same class of silent-render-failure that #368 fixed for `DrawableEntity.getImage`.

- The `except` now logs `_logger.warning("could not load minimap image; keeping last good frame if available", path=..., error=...)` **once on the good→failed transition**, guarded by a new `_miniMapLoadFailed` flag.
- A successful load resets the flag, so the warning re-arms if the minimap recovers and later breaks again.
- This avoids per-reload log spam (the path runs roughly every 60 ticks). Existing fallback-to-cached-or-return behavior is unchanged.

## Test plan

New `tests/screen/test_worldScreen_minimap.py` (+3):

- [x] A corrupt `mapImage.png` is logged exactly once and `drawMiniMap` returns cleanly — **fails without the fix** (which logged nothing).
- [x] Repeated load failures log only once (throttle).
- [x] A successful load resets the failure flag (recovery).
- [x] `python3 -m compileall src -q` clean; `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` → **539 passed** (was 536).
- [x] Black/autoflake scoped to the two changed files; pre-existing Black drift the file-scoped format pulled in (unrelated `status.set`/`_loadOrGenerateRoom` lines) was reverted so the diff carries only the change.

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_