### PR TITLE
ci: auto-mark pre-1.0 releases as pre-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           tag="${{ github.ref_name }}"
+          # While the major version is 0 (pre-1.0), publish as a pre-release.
+          # Drops off automatically at 1.0.0 — no edit needed.
+          prerelease=()
+          if [[ "$tag" == 0.* ]]; then
+            prerelease=(--prerelease)
+          fi
           if ! gh release view "$tag" --repo "${{ github.repository }}" >/dev/null 2>&1; then
             gh release create "$tag" \
               --repo "${{ github.repository }}" \
               --title "Roam $tag" \
               --generate-notes \
-              --verify-tag
+              --verify-tag \
+              "${prerelease[@]}"
           fi
 
   windows:


### PR DESCRIPTION
## What

The `Release` workflow's `gh release create` call omitted `--prerelease`, so a tag-triggered release published as a **full** release — even though the maintainer keeps every 0.x release flagged as a pre-release (done by hand for 0.12.0).

This adds `--prerelease` automatically for any `0.*` tag. The condition drops off on its own at `1.0.0`, so no future edit is needed once Roam goes stable.

## Why now

Surfaced while cutting the 0.12.0 release: the tag built fine but the release had to be manually toggled to pre-release after publish.

## Notes

- Only affects the `create-release` job; the Windows/macOS build+upload jobs are untouched.
- Releases `>= 1.0.0` will publish as full releases, matching the intended convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_