### PR TITLE
refactor: input seam foundation — InputSource/InputEvent/KeyCode (Phase 4a, epic #433)

### DIFF
--- a/src/config/keyBindings.py
+++ b/src/config/keyBindings.py
@@ -1,41 +1,46 @@
-import pygame
+from rendering.keyCode import KeyCode, displayName, fromInt
 
 
 # @author Copilot
 # @since April 19th, 2026
 class KeyBindings:
-    """Manages keybinding defaults, remapping, conflict detection, and persistence."""
+    """Manages keybinding defaults, remapping, conflict detection, and persistence.
+
+    Bindings are stored as backend-neutral KeyCode members (frontend-abstraction
+    epic #433, Phase 4). KeyCode is an IntEnum whose values are the SDL keycodes
+    pygame already used, so existing `key_*` ints in config.yml keep working and
+    comparisons against a frontend's raw key int still hold."""
 
     DEFAULT_BINDINGS = {
-        "move_up": pygame.K_w,
-        "move_left": pygame.K_a,
-        "move_down": pygame.K_s,
-        "move_right": pygame.K_d,
-        "alt_move_up": pygame.K_UP,
-        "alt_move_left": pygame.K_LEFT,
-        "alt_move_down": pygame.K_DOWN,
-        "alt_move_right": pygame.K_RIGHT,
-        "run": pygame.K_LSHIFT,
-        "crouch": pygame.K_LCTRL,
-        "inventory": pygame.K_i,
-        "hotbar_1": pygame.K_1,
-        "hotbar_2": pygame.K_2,
-        "hotbar_3": pygame.K_3,
-        "hotbar_4": pygame.K_4,
-        "hotbar_5": pygame.K_5,
-        "hotbar_6": pygame.K_6,
-        "hotbar_7": pygame.K_7,
-        "hotbar_8": pygame.K_8,
-        "hotbar_9": pygame.K_9,
-        "hotbar_0": pygame.K_0,
-        "toggle_minimap": pygame.K_m,
-        "minimap_zoom_in": pygame.K_EQUALS,
-        "minimap_zoom_out": pygame.K_MINUS,
-        "screenshot": pygame.K_PRINTSCREEN,
-        "toggle_camera_follow": pygame.K_c,
-        "toggle_debug": pygame.K_F3,
-        "toggle_help": pygame.K_F1,
-        "codex": pygame.K_l,
+        "move_up": KeyCode.W,
+        "move_left": KeyCode.A,
+        "move_down": KeyCode.S,
+        "move_right": KeyCode.D,
+        "alt_move_up": KeyCode.UP,
+        "alt_move_left": KeyCode.LEFT,
+        "alt_move_down": KeyCode.DOWN,
+        "alt_move_right": KeyCode.RIGHT,
+        "run": KeyCode.LSHIFT,
+        "crouch": KeyCode.LCTRL,
+        "inventory": KeyCode.I,
+        "hotbar_1": KeyCode.NUM_1,
+        "hotbar_2": KeyCode.NUM_2,
+        "hotbar_3": KeyCode.NUM_3,
+        "hotbar_4": KeyCode.NUM_4,
+        "hotbar_5": KeyCode.NUM_5,
+        "hotbar_6": KeyCode.NUM_6,
+        "hotbar_7": KeyCode.NUM_7,
+        "hotbar_8": KeyCode.NUM_8,
+        "hotbar_9": KeyCode.NUM_9,
+        "hotbar_0": KeyCode.NUM_0,
+        "toggle_minimap": KeyCode.M,
+        "minimap_zoom_in": KeyCode.EQUALS,
+        "minimap_zoom_out": KeyCode.MINUS,
+        "screenshot": KeyCode.PRINTSCREEN,
+        "toggle_camera_follow": KeyCode.C,
+        "toggle_debug": KeyCode.F3,
+        "toggle_help": KeyCode.F1,
+        "codex": KeyCode.L,
     }
 
     ACTION_LABELS = {
@@ -80,6 +85,11 @@ class KeyBindings:
 
     def setKey(self, action, key):
         if action in self.bindings:
+            # Accept either a KeyCode or a raw frontend int (e.g. a captured
+            # key event); store as a KeyCode when we model it, otherwise keep
+            # the raw value so unmodeled keys still rebind and compare.
+            if not isinstance(key, KeyCode):
+                key = fromInt(key) or key
             self.bindings[action] = key
 
     def getActions(self):
@@ -92,7 +102,7 @@ class KeyBindings:
         key = self.bindings.get(action)
         if key is None:
             return "None"
-        return pygame.key.name(key)
+        return displayName(key if isinstance(key, KeyCode) else fromInt(key))
 
     def getConflicts(self):
         """Return a set of actions that share a key with another action."""
@@ -116,18 +126,25 @@ class KeyBindings:
         self.bindings = dict(self.DEFAULT_BINDINGS)
 
     def loadFromConfig(self, configValues):
-        """Load keybinding overrides from config values dict."""
+        """Load keybinding overrides from config values dict.
+
+        Stored values are the raw SDL ints written by earlier versions (and by
+        saveToConfigFile); map each back to a KeyCode so the in-memory model is
+        uniform. An int we don't model is kept as-is so a custom binding still
+        round-trips."""
         for action in self.DEFAULT_BINDINGS:
             configKey = self.CONFIG_PREFIX + action
             value = configValues.get(configKey)
             if isinstance(value, int) and not isinstance(value, bool):
-                self.bindings[action] = value
+                self.bindings[action] = fromInt(value) or value
 
     def saveToConfigFile(self, config):
         """Save current keybindings to config.yml."""
         savedValues = {}
         for action, key in self.bindings.items():
-            savedValues[self.CONFIG_PREFIX + action] = str(key)
+            # Persist the SDL int (KeyCode is an IntEnum) so config.yml stays
+            # backward/forward compatible; str(KeyCode) would write "KeyCode.W".
+            savedValues[self.CONFIG_PREFIX + action] = str(int(key))
 
         config._writeKeyValues(
             savedValues, "failed to save key bindings to config file"

--- a/src/rendering/inputEvent.py
+++ b/src/rendering/inputEvent.py
@@ -1,0 +1,65 @@
+from enum import Enum
+
+
+# @author Daniel McCoy Stephenson
+# @since June 13th, 2026
+#
+# Backend-neutral input event model (frontend-abstraction epic #433, Phase 4).
+# Screens consume InputEvent / EventType instead of pygame event objects and
+# type constants, so the same handling code works behind any InputSource.
+class EventType(Enum):
+    QUIT = "quit"
+    KEY_DOWN = "key_down"
+    KEY_UP = "key_up"
+    MOUSE_DOWN = "mouse_down"
+    MOUSE_UP = "mouse_up"
+    MOUSE_MOTION = "mouse_motion"
+    MOUSE_WHEEL = "mouse_wheel"
+    TEXT_INPUT = "text_input"
+    WINDOW_RESIZE = "window_resize"
+    FOCUS_LOST = "focus_lost"
+    FOCUS_GAINED = "focus_gained"
+    OTHER = "other"
+
+
+class InputEvent:
+    """A single input event. Only the fields relevant to `type` are populated:
+    key (KEY_DOWN/KEY_UP), position + button (MOUSE_DOWN/MOUSE_UP),
+    position (MOUSE_MOTION), scrollY (MOUSE_WHEEL), text (TEXT_INPUT),
+    size (WINDOW_RESIZE).
+
+    `key` is a backend-neutral `KeyCode` (or None for an unmodeled key), so
+    screens and KeyBindings compare against KeyCode members rather than pygame
+    constants. The frontend maps native key events to KeyCode at the boundary.
+    """
+
+    __slots__ = ("type", "key", "position", "button", "scrollY", "text", "size")
+
+    def __init__(
+        self,
+        type,
+        key=None,
+        position=None,
+        button=None,
+        scrollY=0,
+        text=None,
+        size=None,
+    ):
+        self.type = type
+        self.key = key
+        self.position = position
+        self.button = button
+        self.scrollY = scrollY
+        self.text = text
+        self.size = size
+
+    def __repr__(self):
+        return "InputEvent(%r, key=%r, position=%r, button=%r, scrollY=%r, text=%r, size=%r)" % (
+            self.type,
+            self.key,
+            self.position,
+            self.button,
+            self.scrollY,
+            self.text,
+            self.size,
+        )

--- a/src/rendering/inputSource.py
+++ b/src/rendering/inputSource.py
@@ -1,0 +1,33 @@
+from abc import ABC, abstractmethod
+
+
+# @author Daniel McCoy Stephenson
+# @since June 14th, 2026
+#
+# Backend-neutral input interface (frontend-abstraction epic #433, Phase 4).
+#
+# The input half of the seam: screens read events and key/mouse state through
+# this interface instead of calling pygame.event / pygame.key / pygame.mouse
+# directly, so the same screen logic runs behind any frontend. The pygame
+# implementation (PygameInputSource) translates native pygame input into the
+# neutral InputEvent / KeyCode model at the boundary.
+class InputSource(ABC):
+    @abstractmethod
+    def pollEvents(self):
+        """Return the queued input events as a list[InputEvent], draining the
+        underlying queue (replaces pygame.event.get())."""
+
+    @abstractmethod
+    def isPressed(self, keyCode):
+        """Whether the given KeyCode is currently held down (replaces
+        pygame.key.get_pressed()[...])."""
+
+    @abstractmethod
+    def getMousePosition(self):
+        """Current mouse position as an (x, y) tuple (replaces
+        pygame.mouse.get_pos())."""
+
+    @abstractmethod
+    def getMouseButtons(self):
+        """Current mouse button states as a tuple of bools, left-to-right
+        (replaces pygame.mouse.get_pressed())."""

--- a/src/rendering/keyCode.py
+++ b/src/rendering/keyCode.py
@@ -1,0 +1,125 @@
+from enum import IntEnum
+
+
+# @author Daniel McCoy Stephenson
+# @since June 14th, 2026
+#
+# Backend-neutral keyboard codes (frontend-abstraction epic #433, Phase 4).
+#
+# Game logic (KeyBindings, screens) refers to keys by these members instead of
+# pygame's K_* constants, so the same code runs behind any InputSource. An input
+# frontend maps its native key events to/from KeyCode at the boundary.
+#
+# The integer VALUES are the SDL keycodes — i.e. exactly what pygame's K_*
+# constants already are. This is deliberate, for two reasons:
+#   1. Back-compat: existing config.yml `key_*` entries store the old pygame
+#      ints; because KeyCode(<that int>) round-trips, saved keybindings keep
+#      working with no migration.
+#   2. The pygame frontend can map a raw event key with a plain KeyCode(event.key).
+# SDL keycodes are a stable, well-documented standard, so anchoring to them does
+# not couple game logic back to pygame — only the values happen to coincide.
+class KeyCode(IntEnum):
+    # letters
+    A = 97
+    C = 99
+    D = 100
+    I = 105
+    L = 108
+    M = 109
+    S = 115
+    U = 117
+    W = 119
+
+    # digits
+    NUM_0 = 48
+    NUM_1 = 49
+    NUM_2 = 50
+    NUM_3 = 51
+    NUM_4 = 52
+    NUM_5 = 53
+    NUM_6 = 54
+    NUM_7 = 55
+    NUM_8 = 56
+    NUM_9 = 57
+
+    # arrows
+    UP = 1073741906
+    DOWN = 1073741905
+    LEFT = 1073741904
+    RIGHT = 1073741903
+
+    # modifiers
+    LSHIFT = 1073742049
+    RSHIFT = 1073742053
+    LCTRL = 1073742048
+    RCTRL = 1073742052
+
+    # function / special
+    F1 = 1073741882
+    F3 = 1073741884
+    PRINTSCREEN = 1073741894
+    EQUALS = 61
+    MINUS = 45
+    ESCAPE = 27
+    RETURN = 13
+    BACKSPACE = 8
+    SPACE = 32
+
+
+# Human-readable names for the controls UI. Mirrors pygame.key.name() output for
+# the bound keys, so the keybinding screen reads the same after the migration.
+_DISPLAY_NAMES = {
+    KeyCode.A: "a",
+    KeyCode.C: "c",
+    KeyCode.D: "d",
+    KeyCode.I: "i",
+    KeyCode.L: "l",
+    KeyCode.M: "m",
+    KeyCode.S: "s",
+    KeyCode.U: "u",
+    KeyCode.W: "w",
+    KeyCode.NUM_0: "0",
+    KeyCode.NUM_1: "1",
+    KeyCode.NUM_2: "2",
+    KeyCode.NUM_3: "3",
+    KeyCode.NUM_4: "4",
+    KeyCode.NUM_5: "5",
+    KeyCode.NUM_6: "6",
+    KeyCode.NUM_7: "7",
+    KeyCode.NUM_8: "8",
+    KeyCode.NUM_9: "9",
+    KeyCode.UP: "up",
+    KeyCode.DOWN: "down",
+    KeyCode.LEFT: "left",
+    KeyCode.RIGHT: "right",
+    KeyCode.LSHIFT: "left shift",
+    KeyCode.RSHIFT: "right shift",
+    KeyCode.LCTRL: "left ctrl",
+    KeyCode.RCTRL: "right ctrl",
+    KeyCode.F1: "f1",
+    KeyCode.F3: "f3",
+    KeyCode.PRINTSCREEN: "print screen",
+    KeyCode.EQUALS: "=",
+    KeyCode.MINUS: "-",
+    KeyCode.ESCAPE: "escape",
+    KeyCode.RETURN: "return",
+    KeyCode.BACKSPACE: "backspace",
+    KeyCode.SPACE: "space",
+}
+
+
+def fromInt(value):
+    """Map a raw integer keycode to a KeyCode, or None if it is not one we
+    model. Lets a frontend translate native key events without raising on the
+    many keys the game never binds."""
+    try:
+        return KeyCode(value)
+    except ValueError:
+        return None
+
+
+def displayName(keyCode):
+    """Human-readable name for a KeyCode (for the controls screen)."""
+    if keyCode is None:
+        return "None"
+    return _DISPLAY_NAMES.get(keyCode, str(keyCode))

--- a/src/rendering/pygameFrontend.py
+++ b/src/rendering/pygameFrontend.py
@@ -2,6 +2,7 @@ import pygame
 
 from config.config import Config
 from lib.graphik.src.graphik import Graphik
+from rendering.pygameInputSource import PygameInputSource
 from rendering.pygameRenderer import PygameRenderer
 
 _ICON_PATH = "assets/images/player_down.png"
@@ -21,6 +22,7 @@ class PygameFrontend:
         self._config = config
         pygame.init()
         pygame.display.set_icon(pygame.image.load(_ICON_PATH))
+        self._inputSource = PygameInputSource()
         self._buildRenderer()
 
     def _buildRenderer(self):
@@ -41,6 +43,9 @@ class PygameFrontend:
 
     def getRenderer(self):
         return self._renderer
+
+    def getInputSource(self):
+        return self._inputSource
 
     def getGraphik(self):
         return self._graphik

--- a/src/rendering/pygameInputSource.py
+++ b/src/rendering/pygameInputSource.py
@@ -1,0 +1,76 @@
+import pygame
+
+from rendering.inputEvent import EventType, InputEvent
+from rendering.inputSource import InputSource
+from rendering.keyCode import fromInt
+
+
+# @author Daniel McCoy Stephenson
+# @since June 14th, 2026
+#
+# pygame implementation of the input seam (frontend-abstraction epic #433,
+# Phase 4). Translates native pygame events and key/mouse state into the
+# backend-neutral InputEvent / KeyCode model so screens never touch pygame.
+class PygameInputSource(InputSource):
+    # pygame event type -> neutral EventType for the simple (no extra data) cases.
+    _SIMPLE_TYPES = {
+        pygame.QUIT: EventType.QUIT,
+        pygame.MOUSEMOTION: EventType.MOUSE_MOTION,
+        pygame.WINDOWFOCUSLOST: EventType.FOCUS_LOST,
+        pygame.WINDOWFOCUSGAINED: EventType.FOCUS_GAINED,
+    }
+
+    def pollEvents(self):
+        events = []
+        for event in pygame.event.get():
+            translated = self._translate(event)
+            if translated is not None:
+                events.append(translated)
+        return events
+
+    def _translate(self, event):
+        eventType = event.type
+        if eventType in (pygame.KEYDOWN, pygame.KEYUP):
+            neutral = EventType.KEY_DOWN if eventType == pygame.KEYDOWN else EventType.KEY_UP
+            return InputEvent(neutral, key=fromInt(event.key))
+        if eventType in (pygame.MOUSEBUTTONDOWN, pygame.MOUSEBUTTONUP):
+            neutral = (
+                EventType.MOUSE_DOWN
+                if eventType == pygame.MOUSEBUTTONDOWN
+                else EventType.MOUSE_UP
+            )
+            return InputEvent(neutral, position=event.pos, button=event.button)
+        if eventType == pygame.MOUSEMOTION:
+            return InputEvent(EventType.MOUSE_MOTION, position=event.pos)
+        if eventType == pygame.MOUSEWHEEL:
+            return InputEvent(EventType.MOUSE_WHEEL, scrollY=event.y)
+        if eventType == pygame.TEXTINPUT:
+            return InputEvent(EventType.TEXT_INPUT, text=event.text)
+        if eventType in (pygame.VIDEORESIZE, pygame.WINDOWRESIZED):
+            # VIDEORESIZE carries .size; WINDOWRESIZED carries .x/.y (the new
+            # width/height). Normalize both to a (width, height) tuple.
+            size = getattr(event, "size", None)
+            if size is None:
+                size = (event.x, event.y)
+            return InputEvent(EventType.WINDOW_RESIZE, size=size)
+        if eventType in self._SIMPLE_TYPES:
+            return InputEvent(self._SIMPLE_TYPES[eventType])
+        return InputEvent(EventType.OTHER)
+
+    def isPressed(self, keyCode):
+        if keyCode is None:
+            return False
+        pressed = pygame.key.get_pressed()
+        index = int(keyCode)
+        # pygame.key.get_pressed() is indexed by keycode but only spans the
+        # lower range; large SDL keycodes (arrows, modifiers) fall outside it.
+        # Guard so an out-of-range query is a clean False rather than a crash.
+        if 0 <= index < len(pressed):
+            return bool(pressed[index])
+        return False
+
+    def getMousePosition(self):
+        return pygame.mouse.get_pos()
+
+    def getMouseButtons(self):
+        return pygame.mouse.get_pressed()

--- a/src/roam.py
+++ b/src/roam.py
@@ -12,6 +12,7 @@ from gameLogging.logger import getLogger
 from player.player import Player
 from lib.graphik.src.graphik import Graphik
 from rendering.renderer import Renderer
+from rendering.inputSource import InputSource
 from rendering.pygameFrontend import createFrontend
 from screen.configScreen import ConfigScreen
 from screen.controlsScreen import ControlsScreen
@@ -66,6 +67,10 @@ class Roam:
         self.container.registerInstance(Graphik, self.graphik)
         self.renderer = self.frontend.getRenderer()
         self.container.registerInstance(Renderer, self.renderer)
+        # The input seam (epic #433, Phase 4): register the InputSource so
+        # screens can read events/key state through it instead of pygame.
+        self.inputSource = self.frontend.getInputSource()
+        self.container.registerInstance(InputSource, self.inputSource)
         self.status = self.container.resolve(Status)
         self.stats = self.container.resolve(Stats)
         self.player = self.container.resolve(Player)

--- a/tests/config/test_keyBindings.py
+++ b/tests/config/test_keyBindings.py
@@ -7,6 +7,11 @@ import pytest
 from src.config.config import Config
 from src.config.keyBindings import KeyBindings
 
+# Import KeyCode via the production `rendering.*` root (not `src.rendering.*`)
+# so its members are identity-equal to the ones keyBindings stores internally
+# (the two roots resolve to distinct class objects under this repo's pythonpath).
+from rendering.keyCode import KeyCode
+
 
 @pytest.fixture(scope="module", autouse=True)
 def init_pygame():
@@ -206,3 +211,59 @@ def test_no_conflict_when_all_unique():
     # Remap one without collision
     kb.setKey("move_up", pygame.K_KP8)
     assert not kb.hasConflicts()
+
+
+# --- Phase 4 (epic #433): bindings store KeyCode; config stays int-compatible ---
+
+
+def test_defaults_are_keycode_members():
+    kb = KeyBindings()
+    assert kb.getKey("move_up") is KeyCode.W
+    assert isinstance(kb.getKey("inventory"), KeyCode)
+
+
+def test_set_key_coerces_raw_int_to_keycode():
+    # A captured frontend key int is stored as a KeyCode when we model it.
+    kb = KeyBindings()
+    kb.setKey("move_up", pygame.K_UP)
+    assert kb.getKey("move_up") is KeyCode.UP
+
+
+def test_load_from_config_rehydrates_old_int_as_keycode():
+    # config.yml written by earlier versions stores raw SDL ints; they must come
+    # back as KeyCode members, not bare ints.
+    kb = KeyBindings()
+    kb.loadFromConfig({"key_move_up": int(pygame.K_UP)})
+    assert kb.getKey("move_up") is KeyCode.UP
+
+
+def test_save_writes_int_not_enum_repr(tmp_path, monkeypatch):
+    configFilePath = tmp_path / "config.yml"
+    configFilePath.write_text("", encoding="utf-8")
+    monkeypatch.setattr(
+        Config, "getConfigFilePath", staticmethod(lambda: configFilePath)
+    )
+
+    kb = KeyBindings()  # defaults are KeyCode members
+    kb.saveToConfigFile(Config())
+
+    content = configFilePath.read_text(encoding="utf-8")
+    assert "KeyCode" not in content  # never "key_move_up: KeyCode.W"
+    assert "key_move_up: " + str(int(KeyCode.W)) in content
+
+
+def test_unmodeled_key_round_trips_as_raw_int(tmp_path, monkeypatch):
+    # A key the enum doesn't model (e.g. TAB) must still save and reload by int.
+    configFilePath = tmp_path / "config.yml"
+    configFilePath.write_text("", encoding="utf-8")
+    monkeypatch.setattr(
+        Config, "getConfigFilePath", staticmethod(lambda: configFilePath)
+    )
+
+    kb = KeyBindings()
+    kb.setKey("inventory", pygame.K_TAB)
+    kb.saveToConfigFile(Config())
+
+    reloaded = KeyBindings()
+    reloaded.loadFromConfig(Config.readConfigFile())
+    assert reloaded.getKey("inventory") == pygame.K_TAB

--- a/tests/rendering/test_keyCode.py
+++ b/tests/rendering/test_keyCode.py
@@ -1,0 +1,42 @@
+from rendering.keyCode import KeyCode, displayName, fromInt
+
+
+def test_values_are_sdl_keycodes_for_config_back_compat():
+    # The persisted int for each KeyCode must equal the SDL/pygame keycode that
+    # earlier versions stored in config.yml, or saved keybindings would break.
+    assert KeyCode.W == 119
+    assert KeyCode.A == 97
+    assert KeyCode.ESCAPE == 27
+    assert KeyCode.RETURN == 13
+    assert KeyCode.UP == 1073741906
+    assert KeyCode.LSHIFT == 1073742049
+    assert KeyCode.NUM_0 == 48
+
+
+def test_int_enum_compares_equal_to_raw_int():
+    # Screens compare a frontend's raw key int against a KeyCode binding; the
+    # IntEnum makes that comparison hold both directions.
+    assert 119 == KeyCode.W
+    assert KeyCode.W == 119
+    assert int(KeyCode.W) == 119
+
+
+def test_from_int_maps_known_and_unknown():
+    assert fromInt(27) is KeyCode.ESCAPE
+    assert fromInt(119) is KeyCode.W
+    assert fromInt(999999) is None
+
+
+def test_display_name():
+    assert displayName(KeyCode.W) == "w"
+    assert displayName(KeyCode.LSHIFT) == "left shift"
+    assert displayName(KeyCode.EQUALS) == "="
+    assert displayName(None) == "None"
+
+
+def test_keycode_is_hashable_with_int_collisions():
+    # KeyCode hashes like its int, so conflict detection that mixes KeyCode and
+    # raw ints in one dict still collides them correctly.
+    mapping = {KeyCode.W: "binding"}
+    assert mapping[119] == "binding"
+    assert hash(KeyCode.W) == hash(119)

--- a/tests/rendering/test_pygameInputSource.py
+++ b/tests/rendering/test_pygameInputSource.py
@@ -1,0 +1,102 @@
+import os
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
+
+import pygame
+import pytest
+
+from rendering.inputEvent import EventType
+from rendering.keyCode import KeyCode
+from rendering.pygameInputSource import PygameInputSource
+
+
+@pytest.fixture(scope="module", autouse=True)
+def init_pygame():
+    pygame.init()
+    pygame.display.set_mode((100, 100))
+    yield
+    pygame.quit()
+
+
+@pytest.fixture(autouse=True)
+def drain_events():
+    pygame.event.clear()
+    yield
+    pygame.event.clear()
+
+
+def _pollOne(eventDict):
+    pygame.event.clear()
+    pygame.event.post(pygame.event.Event(eventDict.pop("type"), **eventDict))
+    events = PygameInputSource().pollEvents()
+    assert len(events) == 1
+    return events[0]
+
+
+def test_keydown_maps_to_neutral_keycode():
+    event = _pollOne({"type": pygame.KEYDOWN, "key": pygame.K_w})
+    assert event.type is EventType.KEY_DOWN
+    assert event.key is KeyCode.W
+
+
+def test_keyup_maps_to_key_up():
+    event = _pollOne({"type": pygame.KEYUP, "key": pygame.K_ESCAPE})
+    assert event.type is EventType.KEY_UP
+    assert event.key is KeyCode.ESCAPE
+
+
+def test_unmodeled_key_becomes_none():
+    # A key the game never binds (e.g. F12) maps to None rather than raising.
+    event = _pollOne({"type": pygame.KEYDOWN, "key": pygame.K_F12})
+    assert event.type is EventType.KEY_DOWN
+    assert event.key is None
+
+
+def test_mouse_button_down_carries_position_and_button():
+    event = _pollOne({"type": pygame.MOUSEBUTTONDOWN, "pos": (12, 34), "button": 1})
+    assert event.type is EventType.MOUSE_DOWN
+    assert event.position == (12, 34)
+    assert event.button == 1
+
+
+def test_mouse_wheel_carries_scroll():
+    event = _pollOne({"type": pygame.MOUSEWHEEL, "y": -2})
+    assert event.type is EventType.MOUSE_WHEEL
+    assert event.scrollY == -2
+
+
+def test_text_input_carries_text():
+    event = _pollOne({"type": pygame.TEXTINPUT, "text": "Q"})
+    assert event.type is EventType.TEXT_INPUT
+    assert event.text == "Q"
+
+
+def test_quit_maps_to_quit():
+    event = _pollOne({"type": pygame.QUIT})
+    assert event.type is EventType.QUIT
+
+
+def test_poll_drains_and_preserves_order():
+    pygame.event.clear()
+    pygame.event.post(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_a))
+    pygame.event.post(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_d))
+    source = PygameInputSource()
+    events = source.pollEvents()
+    assert [e.key for e in events] == [KeyCode.A, KeyCode.D]
+    # queue is drained
+    assert source.pollEvents() == []
+
+
+def test_is_pressed_is_safe_for_large_keycodes():
+    # Arrow/modifier keycodes fall outside pygame.key.get_pressed()'s range;
+    # the query must return a clean False, never raise.
+    source = PygameInputSource()
+    assert source.isPressed(KeyCode.UP) is False
+    assert source.isPressed(None) is False
+
+
+def test_mouse_helpers_return_state():
+    source = PygameInputSource()
+    assert len(source.getMousePosition()) == 2
+    assert len(source.getMouseButtons()) >= 3


### PR DESCRIPTION
Part of #438 (frontend-abstraction epic #433, Phase 4). See `docs/rendering-abstraction-plan.md` §3b/§3c.

## Scope: Phase **4a** — the testable foundation

Phase 4 (the input seam) is the "hard half" of the epic and the plan calls for landing it incrementally. This PR is **4a**: the backend-neutral input model + its pygame implementation + the subtle `KeyBindings` data-model change. It is **fully unit-testable and behavior-preserving** — no screen event-handling changes yet.

**Deliberately *not* in this PR (Phase 4b/4c):** converting each screen's `handleEvent`, `worldScreen`'s real-time loop, and the §5.1 `drawButton` interaction split. Those change live runtime input and **require the maintainer's smoke-run** (keyboard movement, hotbar, mouse-drag HUD, minimap zoom) — they shouldn't ride in on a green headless suite.

## What's here

- **`rendering/keyCode.py`** — `KeyCode(IntEnum)`. The int values *are* the SDL keycodes pygame already used, which is the trick that makes everything back-compat:
  - existing `config.yml` `key_*` ints keep working with zero migration, and
  - `event.key == keyBindings.getKey(...)` comparisons still hold (IntEnum == its int).
- **`rendering/inputEvent.py`** — `InputEvent.key` is now a neutral `KeyCode`.
- **`rendering/inputSource.py`** — `InputSource` ABC: `pollEvents` / `isPressed` / `getMousePosition` / `getMouseButtons`.
- **`rendering/pygameInputSource.py`** — maps pygame events + key/mouse state into the neutral model. `isPressed` guards the large SDL keycodes (arrows/modifiers) that `pygame.key.get_pressed()` can't index, returning a clean `False`.
- **`config/keyBindings.py`** — stores `KeyCode` members, **no longer imports pygame**; `getKeyName` uses a `KeyCode` display table; persistence stays int-stable (`str(int(key))`, rehydrates ints → `KeyCode`, unmodeled keys round-trip as raw ints).
- **Frontend/DI** — `PygameFrontend` builds + exposes the `InputSource`; `roam.py` registers it in the container so screens can auto-wire it in 4b.

## Why this is safe

`KeyCode` being an `IntEnum` with pygame's values means the change is invisible to existing comparisons and the existing `tests/config/test_keyBindings.py` passes **unchanged** (it asserts `getKey("move_up") == pygame.K_w`, and `KeyCode.W == 119`).

## Tests

Full suite **712 passing**, `black --check` clean, `--selftest` OK. New:
- `test_keyCode` — SDL-value back-compat, IntEnum equality/hashing, `fromInt`, display names.
- `test_pygameInputSource` — event→neutral mapping, unmodeled key → `None`, `isPressed` out-of-range safety, queue drain/order.
- `test_keyBindings` additions — `KeyCode` storage, "int not `KeyCode.W`" persistence, old-int rehydration, unmodeled-key round-trip.

## ⚠️ Note for review

This is foundation only; the grep gate (`pygame` confined to `rendering/`) is **not** satisfied yet — screens still import pygame and will be converted in 4b/4c. Per the epic's process, hold Phase 4 work for a maintainer smoke-run before merging even once 4b/4c land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_