### PR TITLE
refactor: convert menu screens + base loop to the input seam (Phase 4b, epic #433)

### DIFF
--- a/src/rendering/keyCode.py
+++ b/src/rendering/keyCode.py
@@ -62,6 +62,7 @@ class KeyCode(IntEnum):
     MINUS = 45
     ESCAPE = 27
     RETURN = 13
+    KP_ENTER = 1073741912
     BACKSPACE = 8
     SPACE = 32
 
@@ -103,6 +104,7 @@ _DISPLAY_NAMES = {
     KeyCode.MINUS: "-",
     KeyCode.ESCAPE: "escape",
     KeyCode.RETURN: "return",
+    KeyCode.KP_ENTER: "enter",
     KeyCode.BACKSPACE: "backspace",
     KeyCode.SPACE: "space",
 }

--- a/src/rendering/pygameInputSource.py
+++ b/src/rendering/pygameInputSource.py
@@ -2,7 +2,7 @@ import pygame
 
 from rendering.inputEvent import EventType, InputEvent
 from rendering.inputSource import InputSource
-from rendering.keyCode import fromInt
+from rendering.keyCode import KeyCode, fromInt
 
 
 # @author Daniel McCoy Stephenson
@@ -57,14 +57,26 @@ class PygameInputSource(InputSource):
             return InputEvent(self._SIMPLE_TYPES[eventType])
         return InputEvent(EventType.OTHER)
 
+    # Modifier KeyCodes are read from the key-mods bitmask, not get_pressed():
+    # their SDL keycodes are too large to index the get_pressed() array.
+    _MODIFIER_MASKS = {
+        KeyCode.LSHIFT: pygame.KMOD_LSHIFT,
+        KeyCode.RSHIFT: pygame.KMOD_RSHIFT,
+        KeyCode.LCTRL: pygame.KMOD_LCTRL,
+        KeyCode.RCTRL: pygame.KMOD_RCTRL,
+    }
+
     def isPressed(self, keyCode):
         if keyCode is None:
             return False
+        mask = self._MODIFIER_MASKS.get(keyCode)
+        if mask is not None:
+            return bool(pygame.key.get_mods() & mask)
         pressed = pygame.key.get_pressed()
         index = int(keyCode)
         # pygame.key.get_pressed() is indexed by keycode but only spans the
-        # lower range; large SDL keycodes (arrows, modifiers) fall outside it.
-        # Guard so an out-of-range query is a clean False rather than a crash.
+        # lower range; large SDL keycodes (arrows) fall outside it. Guard so an
+        # out-of-range query is a clean False rather than a crash.
         if 0 <= index < len(pressed):
             return bool(pressed[index])
         return False

--- a/src/roam.py
+++ b/src/roam.py
@@ -99,6 +99,7 @@ class Roam:
             SaveSelectionScreen,
             lambda: SaveSelectionScreen(
                 self.container.resolve(Renderer),
+                self.container.resolve(InputSource),
                 self.container.resolve(Config),
                 self.initializeWorldScreen,
             ),

--- a/src/screen/chestScreen.py
+++ b/src/screen/chestScreen.py
@@ -4,10 +4,12 @@ from config.keyBindings import KeyBindings
 from inventory.inventory import Inventory
 from inventory.inventorySlot import InventorySlot
 from rendering.renderer import Renderer
+from rendering.inputSource import InputSource
+from rendering.inputEvent import EventType
+from rendering.keyCode import KeyCode
 from screen.screenType import ScreenType
 from screen.screen import Screen
 from ui.status import Status
-import pygame
 from ui import palette
 
 
@@ -29,12 +31,14 @@ class ChestScreen(Screen):
     def __init__(
         self,
         renderer: Renderer,
+        inputSource: InputSource,
         config: Config,
         status: Status,
         inventory: Inventory,
         keyBindings: KeyBindings,
     ):
         self.renderer = renderer
+        self.inputSource = inputSource
         self.config = config
         self.status = status
         self.inventory = inventory
@@ -103,7 +107,7 @@ class ChestScreen(Screen):
         self.renderer.drawRectangle(
             panelX, panelY, panelWidth, panelHeight, palette.BLACK
         )
-        mouseX, mouseY = pygame.mouse.get_pos()
+        mouseX, mouseY = self.inputSource.getMousePosition()
         hoveredItemName = None
         for index, slot, itemX, itemY, itemWidth, itemHeight in self._slotGeometry(
             inventory, panelRect
@@ -134,7 +138,7 @@ class ChestScreen(Screen):
 
     def _drawTooltip(self, itemName):
         screenWidth, screenHeight = self.renderer.getDisplaySize()
-        mouseX, mouseY = pygame.mouse.get_pos()
+        mouseX, mouseY = self.inputSource.getMousePosition()
         textWidth = len(itemName) * 8 + 12
         tooltipX = mouseX + 18
         tooltipY = mouseY + 18
@@ -179,7 +183,7 @@ class ChestScreen(Screen):
 
     def handleKeyDownEvent(self, key):
         kb = self.keyBindings
-        if key == kb.getKey("inventory") or key == pygame.K_ESCAPE:
+        if key == kb.getKey("inventory") or key == KeyCode.ESCAPE:
             self.switchToWorldScreen()
         elif key == kb.getKey("screenshot"):
             self.renderer.captureScreenshot()
@@ -287,7 +291,7 @@ class ChestScreen(Screen):
 
     def drawDropButton(self):
         buttonX, buttonY, buttonWidth, buttonHeight = self._dropButtonRect()
-        mouseX, mouseY = pygame.mouse.get_pos()
+        mouseX, mouseY = self.inputSource.getMousePosition()
         hovering = (
             buttonX <= mouseX <= buttonX + buttonWidth
             and buttonY <= mouseY <= buttonY + buttonHeight
@@ -356,7 +360,7 @@ class ChestScreen(Screen):
         if self.cursorSlot.isEmpty():
             return
         item = self.cursorSlot.getContents()[0]
-        cursorX, cursorY = pygame.mouse.get_pos()
+        cursorX, cursorY = self.inputSource.getMousePosition()
         scaledImage = self.renderer.scaleImage(
             self.renderer.loadImage(item.getImagePath()), (50, 50)
         )
@@ -388,11 +392,13 @@ class ChestScreen(Screen):
         )
 
     def handleEvent(self, event):
-        if event.type == pygame.KEYDOWN:
+        if event.type == EventType.KEY_DOWN:
             self.handleKeyDownEvent(event.key)
-        elif event.type == pygame.MOUSEBUTTONDOWN:
-            shift = bool(pygame.key.get_mods() & pygame.KMOD_SHIFT)
-            self.handleMouseClickEvent(event.pos, event.button, shift)
+        elif event.type == EventType.MOUSE_DOWN:
+            shift = self.inputSource.isPressed(KeyCode.LSHIFT) or self.inputSource.isPressed(
+                KeyCode.RSHIFT
+            )
+            self.handleMouseClickEvent(event.position, event.button, shift)
 
     def draw(self):
         self.renderer.clearScreen(palette.BLACK)

--- a/src/screen/codexScreen.py
+++ b/src/screen/codexScreen.py
@@ -4,6 +4,9 @@ from codex.codex import Codex, ALL_LIVING_ENTITY_TYPES, ENTITY_IMAGE_PATHS
 from config.config import Config
 from config.keyBindings import KeyBindings
 from rendering.renderer import Renderer
+from rendering.inputSource import InputSource
+from rendering.inputEvent import EventType
+from rendering.keyCode import KeyCode
 from screen.screenType import ScreenType
 from screen.screen import Screen
 from gameLogging.logger import getLogger
@@ -19,11 +22,13 @@ class CodexScreen(Screen):
     def __init__(
         self,
         renderer: Renderer,
+        inputSource: InputSource,
         config: Config,
         codex: Codex,
         keyBindings: KeyBindings,
     ):
         self.renderer = renderer
+        self.inputSource = inputSource
         self.config = config
         self.codex = codex
         self.keyBindings = keyBindings
@@ -161,22 +166,22 @@ class CodexScreen(Screen):
         )
 
     def handleKeyDownEvent(self, key):
-        if key == pygame.K_ESCAPE or key == self.keyBindings.getKey("codex"):
+        if key == KeyCode.ESCAPE or key == self.keyBindings.getKey("codex"):
             self.switchToReturnScreen()
 
     def handleScrollEvent(self, event):
-        if event.y > 0:
+        if event.scrollY > 0:
             self.scrollOffset = max(0, self.scrollOffset - 1)
-        elif event.y < 0:
+        elif event.scrollY < 0:
             self.scrollOffset += 1
 
     def onStart(self):
         self.scrollOffset = 0
 
     def handleEvent(self, event):
-        if event.type == pygame.KEYDOWN:
+        if event.type == EventType.KEY_DOWN:
             self.handleKeyDownEvent(event.key)
-        elif event.type == pygame.MOUSEWHEEL:
+        elif event.type == EventType.MOUSE_WHEEL:
             self.handleScrollEvent(event)
 
     def draw(self):

--- a/src/screen/configScreen.py
+++ b/src/screen/configScreen.py
@@ -2,18 +2,23 @@ import time
 from appContainer import component
 from config.config import Config
 from rendering.renderer import Renderer
+from rendering.inputSource import InputSource
+from rendering.inputEvent import EventType
+from rendering.keyCode import KeyCode
 from screen.screenType import ScreenType
 from screen.screen import Screen
 from ui.status import Status
-import pygame
 from ui import palette
 
 
 # @author Daniel McCoy Stephenson
 @component
 class ConfigScreen(Screen):
-    def __init__(self, renderer: Renderer, config: Config, status: Status):
+    def __init__(
+        self, renderer: Renderer, inputSource: InputSource, config: Config, status: Status
+    ):
         self.renderer = renderer
+        self.inputSource = inputSource
         self.config = config
         self.status = status
         self.running = True
@@ -24,7 +29,7 @@ class ConfigScreen(Screen):
         self._toggleCooldown = 0.25
 
     def handleKeyDownEvent(self, key):
-        if key == pygame.K_ESCAPE:
+        if key == KeyCode.ESCAPE:
             self.switchToMainMenuScreen()
 
     def switchToMainMenuScreen(self):
@@ -124,18 +129,18 @@ class ConfigScreen(Screen):
         )
 
     def handleScrollEvent(self, event):
-        if event.y > 0:
+        if event.scrollY > 0:
             self.scrollOffset = max(0, self.scrollOffset - 1)
-        elif event.y < 0:
+        elif event.scrollY < 0:
             self.scrollOffset += 1
 
     def onStart(self):
         self.scrollOffset = 0
 
     def handleEvent(self, event):
-        if event.type == pygame.KEYDOWN:
+        if event.type == EventType.KEY_DOWN:
             self.handleKeyDownEvent(event.key)
-        elif event.type == pygame.MOUSEWHEEL:
+        elif event.type == EventType.MOUSE_WHEEL:
             self.handleScrollEvent(event)
 
     def draw(self):

--- a/src/screen/controlsScreen.py
+++ b/src/screen/controlsScreen.py
@@ -1,8 +1,10 @@
-import pygame
 from appContainer import component
 from config.config import Config
 from config.keyBindings import KeyBindings
 from rendering.renderer import Renderer
+from rendering.inputSource import InputSource
+from rendering.inputEvent import EventType
+from rendering.keyCode import KeyCode, displayName, fromInt
 from screen.screenType import ScreenType
 from screen.screen import Screen
 from ui import palette
@@ -12,8 +14,15 @@ from ui import palette
 # @since April 19th, 2026
 @component
 class ControlsScreen(Screen):
-    def __init__(self, renderer: Renderer, config: Config, keyBindings: KeyBindings):
+    def __init__(
+        self,
+        renderer: Renderer,
+        inputSource: InputSource,
+        config: Config,
+        keyBindings: KeyBindings,
+    ):
         self.renderer = renderer
+        self.inputSource = inputSource
         self.config = config
         self.keyBindings = keyBindings
         self.nextScreen = ScreenType.OPTIONS_SCREEN
@@ -79,7 +88,7 @@ class ControlsScreen(Screen):
             rowY = startY + i * rowHeight
             label = self.keyBindings.getLabel(action)
             key = bindings.get(action, self.keyBindings.DEFAULT_BINDINGS.get(action))
-            keyName = pygame.key.name(key) if key is not None else "None"
+            keyName = displayName(key if isinstance(key, KeyCode) else fromInt(key))
 
             isConflict = action in conflicts
             labelColor = (255, 100, 100) if isConflict else palette.WHITE
@@ -191,21 +200,24 @@ class ControlsScreen(Screen):
 
     def handleKeyDownEvent(self, key):
         if self.waitingForKey is not None:
-            if key == pygame.K_ESCAPE:
+            if key == KeyCode.ESCAPE:
                 self.waitingForKey = None
+                return
+            if key is None:
+                # An unmodeled key can't be bound; keep waiting for a real one.
                 return
             if self.pendingBindings is None:
                 self.pendingBindings = dict(self.keyBindings.bindings)
             self.pendingBindings[self.waitingForKey] = key
             self.waitingForKey = None
             return
-        if key == pygame.K_ESCAPE:
+        if key == KeyCode.ESCAPE:
             self.cancelAndReturn()
 
     def handleScrollEvent(self, event):
-        if event.y > 0:
+        if event.scrollY > 0:
             self.scrollOffset = max(0, self.scrollOffset - 1)
-        elif event.y < 0:
+        elif event.scrollY < 0:
             self.scrollOffset += 1
 
     def onStart(self):
@@ -214,9 +226,9 @@ class ControlsScreen(Screen):
         self.scrollOffset = 0
 
     def handleEvent(self, event):
-        if event.type == pygame.KEYDOWN:
+        if event.type == EventType.KEY_DOWN:
             self.handleKeyDownEvent(event.key)
-        elif event.type == pygame.MOUSEWHEEL:
+        elif event.type == EventType.MOUSE_WHEEL:
             self.handleScrollEvent(event)
 
     def draw(self):

--- a/src/screen/inventoryScreen.py
+++ b/src/screen/inventoryScreen.py
@@ -6,6 +6,9 @@ from crafting.recipeRegistry import RecipeRegistry
 from inventory.inventory import Inventory
 from inventory.inventorySlot import InventorySlot
 from rendering.renderer import Renderer
+from rendering.inputSource import InputSource
+from rendering.inputEvent import EventType
+from rendering.keyCode import KeyCode
 from screen.screenType import ScreenType
 from screen.screen import Screen
 from ui.status import Status
@@ -19,12 +22,14 @@ class InventoryScreen(Screen):
     def __init__(
         self,
         renderer: Renderer,
+        inputSource: InputSource,
         config: Config,
         status: Status,
         inventory: Inventory,
         keyBindings: KeyBindings,
     ):
         self.renderer = renderer
+        self.inputSource = inputSource
         self.config = config
         self.status = status
         self.inventory = inventory
@@ -66,10 +71,10 @@ class InventoryScreen(Screen):
 
     def handleKeyDownEvent(self, key):
         kb = self.keyBindings
-        if key == pygame.K_ESCAPE and self.craftPanelOpen:
+        if key == KeyCode.ESCAPE and self.craftPanelOpen:
             self.craftPanelOpen = False
             return
-        if key == kb.getKey("inventory") or key == pygame.K_ESCAPE:
+        if key == kb.getKey("inventory") or key == KeyCode.ESCAPE:
             self.switchToWorldScreen()
         elif key == kb.getKey("screenshot"):
             self.renderer.captureScreenshot()
@@ -106,7 +111,7 @@ class InventoryScreen(Screen):
         row = 0
         column = 0
         margin = 5
-        mouseX, mouseY = pygame.mouse.get_pos()
+        mouseX, mouseY = self.inputSource.getMousePosition()
         hoveredItemName = None
         for inventorySlot in self.inventory.getInventorySlots():
             itemX = backgroundX + column * backgroundWidth / itemsPerRow + margin
@@ -432,7 +437,7 @@ class InventoryScreen(Screen):
 
     def drawDropButton(self):
         buttonX, buttonY, buttonWidth, buttonHeight = self._dropButtonRect()
-        mouseX, mouseY = pygame.mouse.get_pos()
+        mouseX, mouseY = self.inputSource.getMousePosition()
         hovering = (
             buttonX <= mouseX <= buttonX + buttonWidth
             and buttonY <= mouseY <= buttonY + buttonHeight
@@ -539,7 +544,7 @@ class InventoryScreen(Screen):
 
         item = self.cursorSlot.getContents()[0]
         image = self.renderer.loadImage(item.getImagePath())
-        cursorX, cursorY = pygame.mouse.get_pos()
+        cursorX, cursorY = self.inputSource.getMousePosition()
         scaledImage = self.renderer.scaleImage(image, (50, 50))
         self.renderer.drawImage(scaledImage, (cursorX, cursorY))
 
@@ -554,10 +559,10 @@ class InventoryScreen(Screen):
             )
 
     def handleEvent(self, event):
-        if event.type == pygame.KEYDOWN:
+        if event.type == EventType.KEY_DOWN:
             self.handleKeyDownEvent(event.key)
-        elif event.type == pygame.MOUSEBUTTONDOWN:
-            self.handleMouseClickEvent(event.pos, event.button)
+        elif event.type == EventType.MOUSE_DOWN:
+            self.handleMouseClickEvent(event.position, event.button)
 
     def draw(self):
         self.renderer.clearScreen(palette.BLACK)

--- a/src/screen/mainMenuScreen.py
+++ b/src/screen/mainMenuScreen.py
@@ -5,6 +5,9 @@ from appContainer import component
 from config.config import Config
 
 from rendering.renderer import Renderer
+from rendering.inputSource import InputSource
+from rendering.inputEvent import EventType
+from rendering.keyCode import KeyCode
 from screen.screenType import ScreenType
 from screen.screen import Screen
 from update.updateChecker import UpdateChecker
@@ -15,9 +18,14 @@ from ui import palette
 @component
 class MainMenuScreen(Screen):
     def __init__(
-        self, renderer: Renderer, config: Config, updateChecker: UpdateChecker
+        self,
+        renderer: Renderer,
+        inputSource: InputSource,
+        config: Config,
+        updateChecker: UpdateChecker,
     ):
         self.renderer = renderer
+        self.inputSource = inputSource
         self.config = config
         self.updateChecker = updateChecker
         self.running = True
@@ -134,18 +142,18 @@ class MainMenuScreen(Screen):
         webbrowser.open(self.updateChecker.getReleasesUrl())
 
     def handleKeyDownEvent(self, key):
-        if key == pygame.K_ESCAPE:
+        if key == KeyCode.ESCAPE:
             self.quitApplication()
-        elif key in (pygame.K_RETURN, pygame.K_KP_ENTER, pygame.K_SPACE):
+        elif key in (KeyCode.RETURN, KeyCode.KP_ENTER, KeyCode.SPACE):
             self.switchToSaveSelectionScreen()
-        elif key == pygame.K_u:
+        elif key == KeyCode.U:
             self.openUpdatePage()
 
     def onStart(self):
         self.updateChecker.checkForUpdatesAsync()
 
     def handleEvent(self, event):
-        if event.type == pygame.KEYDOWN:
+        if event.type == EventType.KEY_DOWN:
             self.handleKeyDownEvent(event.key)
 
     def draw(self):

--- a/src/screen/optionsScreen.py
+++ b/src/screen/optionsScreen.py
@@ -1,18 +1,23 @@
 from appContainer import component
 from config.config import Config
 from rendering.renderer import Renderer
+from rendering.inputSource import InputSource
+from rendering.inputEvent import EventType
+from rendering.keyCode import KeyCode
 from screen.screenType import ScreenType
 from screen.screen import Screen
 from ui.status import Status
-import pygame
 from ui import palette
 
 
 # @author Daniel McCoy Stephenson
 @component
 class OptionsScreen(Screen):
-    def __init__(self, renderer: Renderer, config: Config, status: Status):
+    def __init__(
+        self, renderer: Renderer, inputSource: InputSource, config: Config, status: Status
+    ):
         self.renderer = renderer
+        self.inputSource = inputSource
         self.config = config
         self.status = status
         self.running = True
@@ -21,7 +26,7 @@ class OptionsScreen(Screen):
         self.confirmingMainMenu = False
 
     def handleKeyDownEvent(self, key):
-        if key == pygame.K_ESCAPE:
+        if key == KeyCode.ESCAPE:
             if self.confirmingMainMenu:
                 self.confirmingMainMenu = False
             else:
@@ -175,7 +180,7 @@ class OptionsScreen(Screen):
         )
 
     def handleEvent(self, event):
-        if event.type == pygame.KEYDOWN:
+        if event.type == EventType.KEY_DOWN:
             self.handleKeyDownEvent(event.key)
 
     def draw(self):

--- a/src/screen/saveSelectionScreen.py
+++ b/src/screen/saveSelectionScreen.py
@@ -1,10 +1,13 @@
 import os
 import shutil
 import datetime
-import pygame
+import time
 from config.config import Config
 from gameLogging.logger import getLogger
 from rendering.renderer import Renderer
+from rendering.inputSource import InputSource
+from rendering.inputEvent import EventType
+from rendering.keyCode import KeyCode
 from screen.screenType import ScreenType
 from screen.screen import Screen
 from ui import palette
@@ -18,8 +21,15 @@ class SaveSelectionScreen(Screen):
     SORT_BY_DATE = "date"
     SORT_BY_NAME = "name"
 
-    def __init__(self, renderer: Renderer, config: Config, initializeWorldScreen):
+    def __init__(
+        self,
+        renderer: Renderer,
+        inputSource: InputSource,
+        config: Config,
+        initializeWorldScreen,
+    ):
         self.renderer = renderer
+        self.inputSource = inputSource
         self.config = config
         self.initializeWorldScreen = initializeWorldScreen
         self.nextScreen = ScreenType.MAIN_MENU_SCREEN
@@ -167,22 +177,22 @@ class SaveSelectionScreen(Screen):
 
     def handleKeyDownEvent(self, key):
         if self.namingNewSave:
-            if key == pygame.K_ESCAPE:
+            if key == KeyCode.ESCAPE:
                 self.cancelNamingNewSave()
-            elif key == pygame.K_RETURN:
+            elif key == KeyCode.RETURN:
                 self.confirmNewSaveName()
-            elif key == pygame.K_BACKSPACE:
+            elif key == KeyCode.BACKSPACE:
                 self.newSaveNameInput = self.newSaveNameInput[:-1]
                 self.newSaveNameError = ""
             return
-        if key == pygame.K_ESCAPE:
+        if key == KeyCode.ESCAPE:
             if self.confirmingDelete is not None:
                 self.confirmingDelete = None
             else:
                 self.switchToMainMenuScreen()
-        elif key == pygame.K_UP:
+        elif key == KeyCode.UP:
             self.scrollUp()
-        elif key == pygame.K_DOWN:
+        elif key == KeyCode.DOWN:
             self.scrollDown()
 
     def drawTitle(self):
@@ -484,9 +494,9 @@ class SaveSelectionScreen(Screen):
 
         # Wait for mouse button release to prevent click pass-through
         # from the previous screen (e.g. the main menu "play" button).
-        while pygame.mouse.get_pressed()[0]:
-            for event in pygame.event.get():
-                if event.type == pygame.QUIT:
+        while self.inputSource.getMouseButtons()[0]:
+            for event in self.inputSource.pollEvents():
+                if event.type == EventType.QUIT:
                     self.nextScreen = ScreenType.NONE
                     self.changeScreen = True
                     break
@@ -494,17 +504,17 @@ class SaveSelectionScreen(Screen):
             if self.changeScreen:
                 break
 
-            pygame.time.wait(10)
+            time.sleep(0.01)
 
     def handleEvent(self, event):
-        if event.type == pygame.KEYDOWN:
+        if event.type == EventType.KEY_DOWN:
             self.handleKeyDownEvent(event.key)
-        elif event.type == pygame.MOUSEWHEEL:
-            if event.y > 0:
+        elif event.type == EventType.MOUSE_WHEEL:
+            if event.scrollY > 0:
                 self.scrollUp()
-            elif event.y < 0:
+            elif event.scrollY < 0:
                 self.scrollDown()
-        elif event.type == pygame.TEXTINPUT:
+        elif event.type == EventType.TEXT_INPUT:
             if self.namingNewSave:
                 for ch in event.text:
                     if ch.isalnum() or ch in "-_ ":

--- a/src/screen/screen.py
+++ b/src/screen/screen.py
@@ -1,5 +1,4 @@
-import pygame
-
+from rendering.inputEvent import EventType
 from screen.screenType import ScreenType
 
 
@@ -10,9 +9,11 @@ from screen.screenType import ScreenType
 # (frontend-abstraction epic #433): poll events, draw a frame, present it,
 # until a screen transition is requested. It owns the loop, the common QUIT
 # handling, and the present() call so individual screens stop duplicating that
-# skeleton. Subclasses set self.renderer / self.nextScreen / self.changeScreen
-# (typically in their @component constructor) and override:
-#   - handleEvent(event): act on a non-QUIT event
+# skeleton. Events come from the backend-neutral InputSource as InputEvents, so
+# no screen touches pygame's event queue. Subclasses set self.renderer /
+# self.inputSource / self.nextScreen / self.changeScreen (typically in their
+# @component constructor) and override:
+#   - handleEvent(event): act on a non-QUIT InputEvent
 #   - draw(): clear and render one frame through self.renderer
 #   - onStart(): optional per-run setup before the loop
 #   - onExit(): optional cleanup after the loop
@@ -21,8 +22,8 @@ class Screen:
     def run(self):
         self.onStart()
         while not self.changeScreen:
-            for event in pygame.event.get():
-                if event.type == pygame.QUIT:
+            for event in self.inputSource.pollEvents():
+                if event.type == EventType.QUIT:
                     self.nextScreen = ScreenType.NONE
                     self.changeScreen = True
                     break

--- a/src/screen/statsScreen.py
+++ b/src/screen/statsScreen.py
@@ -2,6 +2,9 @@ from appContainer import component
 from config.config import Config
 from config.keyBindings import KeyBindings
 from rendering.renderer import Renderer
+from rendering.inputSource import InputSource
+from rendering.inputEvent import EventType
+from rendering.keyCode import KeyCode
 from screen.screenType import ScreenType
 from screen.screen import Screen
 from stats.stats import Stats
@@ -17,6 +20,7 @@ class StatsScreen(Screen):
     def __init__(
         self,
         renderer: Renderer,
+        inputSource: InputSource,
         config: Config,
         status: Status,
         stats: Stats,
@@ -24,6 +28,7 @@ class StatsScreen(Screen):
         goals: Goals,
     ):
         self.renderer = renderer
+        self.inputSource = inputSource
         self.config = config
         self.status = status
         self.stats = stats
@@ -33,7 +38,7 @@ class StatsScreen(Screen):
         self.changeScreen = False
 
     def handleKeyDownEvent(self, key):
-        if key == pygame.K_ESCAPE:
+        if key == KeyCode.ESCAPE:
             self.switchToOptionsScreen()
         elif key == self.keyBindings.getKey("screenshot"):
             self.renderer.captureScreenshot()
@@ -130,7 +135,7 @@ class StatsScreen(Screen):
         )
 
     def handleEvent(self, event):
-        if event.type == pygame.KEYDOWN:
+        if event.type == EventType.KEY_DOWN:
             self.handleKeyDownEvent(event.key)
 
     def draw(self):

--- a/tests/codex/test_codexScreen.py
+++ b/tests/codex/test_codexScreen.py
@@ -3,6 +3,7 @@ import pytest
 from unittest.mock import MagicMock
 
 from codex.codex import ALL_LIVING_ENTITY_TYPES
+from rendering.inputEvent import EventType, InputEvent
 from screen.codexScreen import CodexScreen
 
 
@@ -48,26 +49,20 @@ def test_handle_escape_key(pygame_init, resolve, test_graphik):
 
 def test_handle_scroll_event_down(pygame_init, resolve, test_graphik):
     screen = createCodexScreen(pygame_init, resolve, test_graphik)
-    event = MagicMock()
-    event.y = -1
-    screen.handleScrollEvent(event)
+    screen.handleScrollEvent(InputEvent(EventType.MOUSE_WHEEL, scrollY=-1))
     assert screen.scrollOffset == 1
 
 
 def test_handle_scroll_event_up(pygame_init, resolve, test_graphik):
     screen = createCodexScreen(pygame_init, resolve, test_graphik)
     screen.scrollOffset = 1
-    event = MagicMock()
-    event.y = 1
-    screen.handleScrollEvent(event)
+    screen.handleScrollEvent(InputEvent(EventType.MOUSE_WHEEL, scrollY=1))
     assert screen.scrollOffset == 0
 
 
 def test_scroll_does_not_go_below_zero(pygame_init, resolve, test_graphik):
     screen = createCodexScreen(pygame_init, resolve, test_graphik)
-    event = MagicMock()
-    event.y = 1
-    screen.handleScrollEvent(event)
+    screen.handleScrollEvent(InputEvent(EventType.MOUSE_WHEEL, scrollY=1))
     assert screen.scrollOffset == 0
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,8 @@ from config.keyBindings import KeyBindings
 from lib.graphik.src.graphik import Graphik
 from rendering.renderer import Renderer
 from rendering.pygameRenderer import PygameRenderer
+from rendering.inputSource import InputSource
+from rendering.pygameInputSource import PygameInputSource
 
 os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
 os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
@@ -57,10 +59,25 @@ def test_renderer():
 
 
 @pytest.fixture
-def test_di_container(test_config, test_graphik, test_renderer):
+def test_input_source():
+    # InputSource mock for screens migrated to the input seam (epic #433,
+    # Phase 4). Defaults to no queued events and a quiescent mouse so a screen's
+    # draw()/run() can be exercised headless; tests that drive specific input
+    # override pollEvents / getMousePosition / getMouseButtons / isPressed.
+    inputSource = MagicMock(spec=PygameInputSource)
+    inputSource.pollEvents.return_value = []
+    inputSource.getMousePosition.return_value = (0, 0)
+    inputSource.getMouseButtons.return_value = (False, False, False)
+    inputSource.isPressed.return_value = False
+    return inputSource
+
+
+@pytest.fixture
+def test_di_container(test_config, test_graphik, test_renderer, test_input_source):
     createContainer(test_config)
     container.registerInstance(Graphik, test_graphik)
     container.registerInstance(Renderer, test_renderer)
+    container.registerInstance(InputSource, test_input_source)
     container.register(
         InventoryJsonReaderWriter,
         lambda: InventoryJsonReaderWriter(container.resolve(Config)),

--- a/tests/rendering/test_keyCode.py
+++ b/tests/rendering/test_keyCode.py
@@ -11,6 +11,7 @@ def test_values_are_sdl_keycodes_for_config_back_compat():
     assert KeyCode.UP == 1073741906
     assert KeyCode.LSHIFT == 1073742049
     assert KeyCode.NUM_0 == 48
+    assert KeyCode.KP_ENTER == 1073741912
 
 
 def test_int_enum_compares_equal_to_raw_int():

--- a/tests/rendering/test_pygameInputSource.py
+++ b/tests/rendering/test_pygameInputSource.py
@@ -89,11 +89,21 @@ def test_poll_drains_and_preserves_order():
 
 
 def test_is_pressed_is_safe_for_large_keycodes():
-    # Arrow/modifier keycodes fall outside pygame.key.get_pressed()'s range;
-    # the query must return a clean False, never raise.
+    # Arrow keycodes fall outside pygame.key.get_pressed()'s range; the query
+    # must return a clean False, never raise.
     source = PygameInputSource()
     assert source.isPressed(KeyCode.UP) is False
     assert source.isPressed(None) is False
+
+
+def test_is_pressed_reads_modifiers_from_key_mods(monkeypatch):
+    # Shift/ctrl can't be read via get_pressed() (their keycodes are too large),
+    # so isPressed routes modifier queries through pygame.key.get_mods().
+    source = PygameInputSource()
+    monkeypatch.setattr(pygame.key, "get_mods", lambda: pygame.KMOD_LSHIFT)
+    assert source.isPressed(KeyCode.LSHIFT) is True
+    assert source.isPressed(KeyCode.RSHIFT) is False
+    assert source.isPressed(KeyCode.LCTRL) is False
 
 
 def test_mouse_helpers_return_state():

--- a/tests/rendering/test_pygameRenderer_smoke.py
+++ b/tests/rendering/test_pygameRenderer_smoke.py
@@ -108,7 +108,10 @@ def test_main_menu_screen_draw_path_runs(renderer):
     updateChecker.getLatestVersion.return_value = "9.9.9"
     updateChecker.getReleasesUrl.return_value = "https://example.invalid/releases"
 
-    screen = MainMenuScreen(renderer, config, updateChecker)
+    inputSource = MagicMock()
+    inputSource.getMousePosition.return_value = (0, 0)
+    inputSource.getMouseButtons.return_value = (False, False, False)
+    screen = MainMenuScreen(renderer, inputSource, config, updateChecker)
     renderer.clearScreen(palette.BLACK)
     screen.drawText()
     screen.drawMenuButtons()

--- a/tests/screen/test_chestScreen.py
+++ b/tests/screen/test_chestScreen.py
@@ -30,8 +30,14 @@ def createChestScreen(playerInventory=None, chest=None):
     renderer.getDisplayHeight.return_value = 600
     renderer.getDisplaySize.return_value = (800, 600)
 
+    inputSource = MagicMock()
+    inputSource.getMousePosition.return_value = (0, 0)
+    inputSource.getMouseButtons.return_value = (False, False, False)
+    inputSource.isPressed.return_value = False
+
     screen = ChestScreen.__new__(ChestScreen)
     screen.renderer = renderer
+    screen.inputSource = inputSource
     screen.config = MagicMock()
     screen.status = MagicMock()
     screen.keyBindings = MagicMock()
@@ -119,7 +125,7 @@ def test_draw_panel_returns_hovered_item_name(monkeypatch):
     )
     _, _, itemX, itemY, itemWidth, itemHeight = geometry[0]
     centre = (int(itemX + itemWidth / 2), int(itemY + itemHeight / 2))
-    monkeypatch.setattr(pygame.mouse, "get_pos", lambda: centre)
+    screen.inputSource.getMousePosition.return_value = centre
 
     hovered = screen._drawPanel(
         screen.getChestInventory(), screen.getChestPanelRect(), "Chest"

--- a/tests/screen/test_inventoryScreen_drop.py
+++ b/tests/screen/test_inventoryScreen_drop.py
@@ -5,6 +5,8 @@ from src.inventory.inventory import Inventory
 from src.entity.grass import Grass
 from src.lib.graphik.src.graphik import Graphik
 from src.rendering.pygameRenderer import PygameRenderer
+from rendering.inputEvent import EventType, InputEvent
+from rendering.keyCode import KeyCode
 from src.screen.inventoryScreen import InventoryScreen
 
 
@@ -14,11 +16,16 @@ def createInventoryScreen():
     gameDisplay.get_height.return_value = 600
     gameDisplay.get_size.return_value = (800, 600)
     renderer = PygameRenderer(Graphik(gameDisplay))
+    inputSource = MagicMock()
+    inputSource.getMousePosition.return_value = (0, 0)
+    inputSource.getMouseButtons.return_value = (False, False, False)
     config = MagicMock()
     status = MagicMock()
     inventory = Inventory()
     keyBindings = KeyBindings()
-    return InventoryScreen(renderer, config, status, inventory, keyBindings)
+    return InventoryScreen(
+        renderer, inputSource, config, status, inventory, keyBindings
+    )
 
 
 def createGrass():
@@ -136,6 +143,28 @@ def test_dropOneFromCursorSlot_does_not_affect_inventory():
 
     assert screen.cursorSlot.getNumItems() == 2
     assert screen.inventory.getNumItems() == 1
+
+
+# --- handleEvent dispatch (input seam, epic #433 Phase 4) ---
+
+
+def test_handleEvent_keydown_escape_closes_to_world_screen():
+    # A neutral KEY_DOWN InputEvent carrying KeyCode.ESCAPE routes through the
+    # converted handleEvent -> handleKeyDownEvent and requests the transition.
+    screen = createInventoryScreen()
+    screen.handleEvent(InputEvent(EventType.KEY_DOWN, key=KeyCode.ESCAPE))
+    assert screen.changeScreen is True
+
+
+def test_handleEvent_mouse_down_dispatches_with_position_and_button():
+    # A MOUSE_DOWN InputEvent's position/button reach handleMouseClickEvent.
+    screen = createInventoryScreen()
+    captured = {}
+    screen.handleMouseClickEvent = lambda pos, button: captured.update(
+        pos=pos, button=button
+    )
+    screen.handleEvent(InputEvent(EventType.MOUSE_DOWN, position=(42, 99), button=3))
+    assert captured == {"pos": (42, 99), "button": 3}
 
 
 # --- handleMouseClickEvent integration tests ---

--- a/tests/screen/test_saveSelectionScreen.py
+++ b/tests/screen/test_saveSelectionScreen.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import tempfile
+from unittest.mock import MagicMock
 
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 import pygame
@@ -32,7 +33,13 @@ def createSaveSelectionScreen(savesDir):
     gameDisplay = pygame.display.set_mode((800, 600))
     graphik = Graphik(gameDisplay)
     initializeWorldScreen = lambda: None
-    screen = SaveSelectionScreen(PygameRenderer(graphik), config, initializeWorldScreen)
+    inputSource = MagicMock()
+    inputSource.getMousePosition.return_value = (0, 0)
+    inputSource.getMouseButtons.return_value = (False, False, False)
+    inputSource.pollEvents.return_value = []
+    screen = SaveSelectionScreen(
+        PygameRenderer(graphik), inputSource, config, initializeWorldScreen
+    )
     screen.savesBaseDirectory = savesDir
     return screen
 

--- a/tests/screen/test_screen.py
+++ b/tests/screen/test_screen.py
@@ -1,31 +1,25 @@
 from unittest.mock import MagicMock
 
-import pygame
-
+from rendering.inputEvent import EventType, InputEvent
 from screen.screen import Screen
 from screen.screenType import ScreenType
 
 
-class _FakeEvent:
-    def __init__(self, eventType):
-        self.type = eventType
+class _FakeInputSource:
+    """Returns each frame's InputEvent list in turn, then [] forever — so the
+    base loop is driven deterministically without touching pygame."""
 
+    def __init__(self, *frames):
+        self._frames = list(frames)
 
-def _eventGetReturning(*frames):
-    """Build a pygame.event.get replacement that returns each frame's event
-    list in turn, then [] forever — so the loop is driven deterministically
-    without touching the global pygame event queue (which leaks across tests)."""
-    queue = list(frames)
-
-    def fake_get():
-        return queue.pop(0) if queue else []
-
-    return fake_get
+    def pollEvents(self):
+        return self._frames.pop(0) if self._frames else []
 
 
 class _RecordingScreen(Screen):
-    def __init__(self, stopAfterFrames=1):
+    def __init__(self, inputSource, stopAfterFrames=1):
         self.renderer = MagicMock()
+        self.inputSource = inputSource
         self.nextScreen = ScreenType.OPTIONS_SCREEN
         self.changeScreen = False
         self.starts = 0
@@ -49,9 +43,8 @@ class _RecordingScreen(Screen):
             self.changeScreen = True
 
 
-def test_loop_draws_presents_and_returns_next_screen(monkeypatch):
-    monkeypatch.setattr(pygame.event, "get", _eventGetReturning())
-    screen = _RecordingScreen(stopAfterFrames=1)
+def test_loop_draws_presents_and_returns_next_screen():
+    screen = _RecordingScreen(_FakeInputSource(), stopAfterFrames=1)
     result = screen.run()
     assert result == ScreenType.OPTIONS_SCREEN
     assert screen.frames == 1
@@ -61,21 +54,17 @@ def test_loop_draws_presents_and_returns_next_screen(monkeypatch):
     assert screen.changeScreen is False
 
 
-def test_quit_event_requests_shutdown_without_dispatching_to_handle_event(monkeypatch):
-    monkeypatch.setattr(
-        pygame.event, "get", _eventGetReturning([_FakeEvent(pygame.QUIT)])
-    )
-    screen = _RecordingScreen(stopAfterFrames=99)
+def test_quit_event_requests_shutdown_without_dispatching_to_handle_event():
+    inputSource = _FakeInputSource([InputEvent(EventType.QUIT)])
+    screen = _RecordingScreen(inputSource, stopAfterFrames=99)
     result = screen.run()
     assert result == ScreenType.NONE
     assert screen.handled == []  # QUIT handled by the base, not the subclass
 
 
-def test_non_quit_events_are_dispatched_to_handle_event(monkeypatch):
-    monkeypatch.setattr(
-        pygame.event, "get", _eventGetReturning([_FakeEvent(pygame.KEYDOWN)])
-    )
-    screen = _RecordingScreen(stopAfterFrames=99)
+def test_non_quit_events_are_dispatched_to_handle_event():
+    inputSource = _FakeInputSource([InputEvent(EventType.KEY_DOWN)])
+    screen = _RecordingScreen(inputSource, stopAfterFrames=99)
 
     def handle(event):
         screen.handled.append(event.type)
@@ -83,5 +72,5 @@ def test_non_quit_events_are_dispatched_to_handle_event(monkeypatch):
 
     screen.handleEvent = handle
     result = screen.run()
-    assert pygame.KEYDOWN in screen.handled
+    assert EventType.KEY_DOWN in screen.handled
     assert result == ScreenType.OPTIONS_SCREEN


### PR DESCRIPTION
Part of #438 (frontend-abstraction epic #433, Phase 4). Builds directly on **4a** (#454, merged).

## Scope: Phase **4b** — menu screens off pygame input

The `Screen` base loop and all **nine** menu screens now consume the backend-neutral `InputEvent` / `KeyCode` model through the `InputSource`, instead of touching `pygame.event` / `pygame.key` / `pygame.mouse`.

**Not in this PR (Phase 4c):** `worldScreen` (its own real-time game loop — movement, mouse-drag HUD, minimap zoom, frame pacing) and the §5.1 `drawButton` interaction split. Those change live input behavior and **need the maintainer's smoke-run**.

## What changed

- **`screen/screen.py`** base loop polls `self.inputSource.pollEvents()`, handles QUIT via `EventType.QUIT`, dispatches `InputEvent`s — no pygame.
- **9 screens** (`mainMenu`, `stats`, `options`, `config`, `controls`, `codex`, `saveSelection`, `inventory`, `chest`): inject `InputSource`; `handleEvent` switches on `EventType`; `handleKeyDownEvent` compares `KeyCode`; scroll reads `event.scrollY`; clicks read `event.position`; `pygame.mouse.get_pos()` → `inputSource.getMousePosition()`; chest shift-click → `inputSource.isPressed(LSHIFT/RSHIFT)`; controls key labels → `KeyCode` display table; saveSelection's mouse-release wait + text entry go through the `InputSource`.
- **infra**: `KeyCode.KP_ENTER` (mainMenu's keypad-enter); `PygameInputSource.isPressed` reads modifiers via `pygame.key.get_mods()` (their SDL keycodes are too large for `get_pressed()`).

## Out of scope on purpose

`pygame.quit()` lifecycle calls (3 screens) and codexScreen's image/font cache are **output/lifecycle** concerns, not the input seam — flagged for later cleanup. So the full `pygame`-confined-to-`rendering/` grep gate isn't closed until those + 4c land.

## Why it's low-risk

`KeyCode` is an `IntEnum` with pygame's values, so the existing screen tests — which call `handleKeyDownEvent(pygame.K_ESCAPE)` and `handleMouseClickEvent((x,y), button)` directly — pass **unchanged**. The base-loop test was rewritten to drive a fake `InputSource`.

## Tests

**715 passing**, `black --check` clean, `--selftest` OK. New: modifier `isPressed`, `KP_ENTER`, and an end-to-end `handleEvent(InputEvent(...))` dispatch through a converted screen. conftest registers a mock `InputSource` so `resolve(Screen)` auto-wires.

## ⚠️ For review

Like 4a, this is input-seam work — please hold for a maintainer smoke-run (open the menus: navigate with keys, scroll the codex/controls, rebind a key, name a new save with typing/backspace, shift-click in a chest) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_