### PR TITLE
fix: text-mode hover tooltip (#483) and terminal resize (#482)

### DIFF
--- a/src/rendering/textFrontend.py
+++ b/src/rendering/textFrontend.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 from config.config import Config
+from rendering.inputEvent import EventType, InputEvent
 from rendering.textClock import TextClock
 from rendering.textInputSource import TextInputSource
 from rendering.textRenderer import TextRenderer
@@ -27,15 +28,15 @@ from rendering.textRenderer import TextRenderer
 #       * Place (right-click): use F to place/interact with the tile in front of you.
 #       * Hotbar slots cannot be clicked; use 1–0 keys instead.
 #       * HUD elements (hotbar, minimap, status) cannot be dragged.
-#       * The "hover over a tile to show its name" status tooltip always reads
-#         whatever entity is at grid cell (0, 0).
+#       * The "hover over a tile" status tooltip is suppressed (no mouse).
 #       * The scroll wheel cannot cycle the hotbar; use 1–0 or [ ] instead.
 #   - No held-key state. isPressed() always returns False, so Run (hold Shift)
 #     and Crouch (hold Ctrl) have no effect. Each directional keypress moves
 #     the player exactly one tile (a synthetic KEY_UP follows each movement
 #     KEY_DOWN to prevent OS key-repeat from causing continuous walking).
-#   - Terminal resize is handled via SIGWINCH (Unix only). On non-Unix
-#     platforms the grid is sized once at startup; restart after resizing.
+#   - Terminal resize is handled via SIGWINCH (Unix only): the grid is resized
+#     and a WINDOW_RESIZE event is queued so worldScreen recalculates cell dims.
+#     On non-Unix platforms the grid is sized once at startup; restart after resizing.
 #
 # RENDERING
 #   - Minimap renders as a [map] text placeholder. Room PNG files are never
@@ -89,6 +90,7 @@ class TextFrontend:
 
     def _onResize(self, signum, frame):
         self._renderer.resize(self._termCols(), self._termRows())
+        self._inputSource.queueEvent(InputEvent(EventType.WINDOW_RESIZE))
 
     def _enterCbreakMode(self):
         # Non-canonical, no-echo input so keystrokes arrive immediately. Skipped

--- a/src/rendering/textInputSource.py
+++ b/src/rendering/textInputSource.py
@@ -58,8 +58,14 @@ _CONTROL_CHARS = {
 class TextInputSource(InputSource):
     def __init__(self, charReader=None):
         self._charReader = charReader if charReader is not None else _readStdinChars
+        self._pendingEvents = []
+
+    def queueEvent(self, event):
+        self._pendingEvents.append(event)
 
     def pollEvents(self):
+        pending = self._pendingEvents[:]
+        self._pendingEvents.clear()
         chars = self._charReader()
         events = []
         index = 0
@@ -86,7 +92,7 @@ class TextInputSource(InputSource):
             if char.isprintable():
                 events.append(InputEvent(EventType.TEXT_INPUT, text=char))
             index += 1
-        return events
+        return pending + events
 
     def isPressed(self, keyCode):
         # A line/character terminal has no reliable held-key state.

--- a/src/rendering/textInputSource.py
+++ b/src/rendering/textInputSource.py
@@ -64,8 +64,9 @@ class TextInputSource(InputSource):
         self._pendingEvents.append(event)
 
     def pollEvents(self):
-        pending = self._pendingEvents[:]
-        self._pendingEvents.clear()
+        # Atomic swap under CPython's GIL: a SIGWINCH arriving between the two
+        # lines of a copy-then-clear could silently drop the queued event.
+        pending, self._pendingEvents = self._pendingEvents, []
         chars = self._charReader()
         events = []
         index = 0

--- a/src/screen/worldScreen.py
+++ b/src/screen/worldScreen.py
@@ -2208,7 +2208,8 @@ class WorldScreen:
         self.currentRoom.tickExcrement(self.tickCounter.getTick(), self.config)
         self.currentRoom.tickCrops(self.tickCounter.getTick(), self.config)
 
-        self.handleMouseOver()
+        if self.renderer.supportsImageLoading():
+            self.handleMouseOver()
 
         if self.deathRespawnTicksRemaining == 0:
             self.handlePlayerActions()

--- a/tests/rendering/test_textInputSource.py
+++ b/tests/rendering/test_textInputSource.py
@@ -301,3 +301,35 @@ def test_multiple_chars_in_burst_decoded_in_order():
     source = _sourceFeeding("acd")
     keys = [e.key for e in source.pollEvents() if e.type is EventType.KEY_DOWN]
     assert keys == [KeyCode.A, KeyCode.C, KeyCode.D]
+
+
+def test_queued_event_returned_before_char_events():
+    from rendering.inputEvent import InputEvent
+
+    source = _sourceFeeding("a")
+    resize = InputEvent(EventType.WINDOW_RESIZE)
+    source.queueEvent(resize)
+    events = source.pollEvents()
+    assert events[0] is resize
+    assert any(e.type is EventType.KEY_DOWN and e.key is KeyCode.A for e in events)
+
+
+def test_queued_event_returned_exactly_once():
+    from rendering.inputEvent import InputEvent
+
+    source = _sourceFeeding("")
+    source.queueEvent(InputEvent(EventType.WINDOW_RESIZE))
+    first = source.pollEvents()
+    second = source.pollEvents()
+    assert len([e for e in first if e.type is EventType.WINDOW_RESIZE]) == 1
+    assert len([e for e in second if e.type is EventType.WINDOW_RESIZE]) == 0
+
+
+def test_multiple_queued_events_all_returned():
+    from rendering.inputEvent import InputEvent
+
+    source = _sourceFeeding("")
+    source.queueEvent(InputEvent(EventType.WINDOW_RESIZE))
+    source.queueEvent(InputEvent(EventType.WINDOW_RESIZE))
+    events = source.pollEvents()
+    assert len([e for e in events if e.type is EventType.WINDOW_RESIZE]) == 2


### PR DESCRIPTION
## Summary

- **#483** — suppress spurious cell-(0,0) hover tooltip in text mode: guard `handleMouseOver()` behind `renderer.supportsImageLoading()` so it's never called when there's no mouse
- **#482** — complete terminal-resize support: add `queueEvent()`/`_pendingEvents` to `TextInputSource` so `TextFrontend._onResize` can push a `WINDOW_RESIZE` event alongside `renderer.resize()`, triggering `worldScreen.initializeLocationWidthAndHeight()` on the next poll cycle

Also closes #487 and #484 (already fixed in the previous PR; verified and closed).

## Test plan
- [ ] 918 tests passing (`python3 -m pytest tests/ -q`)
- [ ] `black --check` clean
- [ ] Smoke: `python3 src/roam.py --text` — status bar no longer shows a ghost entity name while idle
- [ ] Smoke: resize terminal mid-game — map reflows to new dimensions within one frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_