### PR TITLE
feat: five UX improvements — pickup, hints, click, WASD, new-save CTA

### DIFF
--- a/src/lib/graphik/src/graphik.py
+++ b/src/lib/graphik/src/graphik.py
@@ -17,6 +17,20 @@ class Graphik:
 
     def __init__(self, gameDisplay):
         self.gameDisplay = gameDisplay
+        self._mouseDownPrev = False
+        self._mouseDownCurrent = False
+        self._frameStarted = False
+
+    def beginFrame(self):
+        """Snapshot mouse state once per frame so drawButton fires only on the
+        down-transition (press), not continuously while the button is held."""
+        if not self._frameStarted:
+            self._mouseDownPrev = self._mouseDownCurrent
+            self._mouseDownCurrent = pygame.mouse.get_pressed()[0] == 1
+            self._frameStarted = True
+
+    def endFrame(self):
+        self._frameStarted = False
 
     def getGameDisplay(self):
         return self.gameDisplay
@@ -70,7 +84,5 @@ class Graphik:
             text, xpos + (width // 2), ypos + (height // 2), sizeText, colorText
         )
 
-        if hovering:
-            click = pygame.mouse.get_pressed()
-            if click[0] == 1:
-                function()
+        if hovering and self._mouseDownCurrent and not self._mouseDownPrev:
+            function()

--- a/src/rendering/pygameRenderer.py
+++ b/src/rendering/pygameRenderer.py
@@ -48,9 +48,11 @@ class PygameRenderer(Renderer):
         return self._display().get_height()
 
     def clearScreen(self, color):
+        self.graphik.beginFrame()
         self._display().fill(color)
 
     def present(self):
+        self.graphik.endFrame()
         pygame.display.update()
 
     def setCaption(self, text):

--- a/src/screen/controlsScreen.py
+++ b/src/screen/controlsScreen.py
@@ -238,9 +238,9 @@ class ControlsScreen(Screen):
             return
         if key == KeyCode.ESCAPE:
             self.cancelAndReturn()
-        elif key == KeyCode.UP:
+        elif key in (KeyCode.UP, KeyCode.W):
             self._cursor = max(0, self._cursor - 1)
-        elif key == KeyCode.DOWN:
+        elif key in (KeyCode.DOWN, KeyCode.S):
             actions = self.keyBindings.getActions()
             self._cursor = min(len(actions) - 1, self._cursor + 1)
         elif key in (KeyCode.RETURN, KeyCode.KP_ENTER, KeyCode.SPACE):

--- a/src/screen/mainMenuScreen.py
+++ b/src/screen/mainMenuScreen.py
@@ -91,7 +91,7 @@ class MainMenuScreen(Screen):
         hintY = startY + len(self._MENU_ITEMS) * (height + margin) + 6
         selectedLabel = self._MENU_ITEMS[self._selectedIndex][0]
         self.renderer.drawText(
-            f"Up/Down: navigate  -  Enter: {selectedLabel}  -  Esc: Quit",
+            f"W/S or Up/Down: navigate  -  Enter: {selectedLabel}  -  Esc: Quit",
             x / 2,
             hintY,
             16,
@@ -135,9 +135,9 @@ class MainMenuScreen(Screen):
     def handleKeyDownEvent(self, key):
         if key == KeyCode.ESCAPE:
             self.quitApplication()
-        elif key == KeyCode.UP:
+        elif key in (KeyCode.UP, KeyCode.W):
             self._selectedIndex = (self._selectedIndex - 1) % len(self._MENU_ITEMS)
-        elif key == KeyCode.DOWN:
+        elif key in (KeyCode.DOWN, KeyCode.S):
             self._selectedIndex = (self._selectedIndex + 1) % len(self._MENU_ITEMS)
         elif key in (KeyCode.RETURN, KeyCode.KP_ENTER, KeyCode.SPACE):
             getattr(self, self._MENU_ITEMS[self._selectedIndex][1])()

--- a/src/screen/saveSelectionScreen.py
+++ b/src/screen/saveSelectionScreen.py
@@ -212,11 +212,11 @@ class SaveSelectionScreen(Screen):
             return
         if key == KeyCode.ESCAPE:
             self.switchToMainMenuScreen()
-        elif key == KeyCode.UP:
+        elif key in (KeyCode.UP, KeyCode.W):
             saves = self.getSaveDirectories()
             maxVisible = self._maxVisible()
             self._moveCursorUp(saves, maxVisible)
-        elif key == KeyCode.DOWN:
+        elif key in (KeyCode.DOWN, KeyCode.S):
             saves = self.getSaveDirectories()
             maxVisible = self._maxVisible()
             self._moveCursorDown(saves, maxVisible)
@@ -263,15 +263,37 @@ class SaveSelectionScreen(Screen):
     def drawNoSavesMessage(self):
         x, y = self.renderer.getDisplaySize()
         xpos = x / 2
-        ypos = y / 3
-        self.renderer.drawText("No save files found.", xpos, ypos, 28, palette.WHITE)
-        ypos += 40
+        ypos = y / 5
+        self.renderer.drawText("Welcome to Roam!", xpos, ypos, 32, palette.WHITE)
+        ypos += 44
         self.renderer.drawText(
-            "Press C to create a new save.",
+            "No saves found. Create your first save to start playing.",
             xpos,
             ypos,
-            24,
+            20,
             palette.GRAY,
+        )
+        btnWidth = x / 4
+        btnHeight = y / 9
+        btnX = xpos - btnWidth / 2
+        btnY = y * 0.40
+        self.renderer.drawButton(
+            btnX,
+            btnY,
+            btnWidth,
+            btnHeight,
+            palette.GREEN,
+            palette.WHITE,
+            28,
+            "Create New Save",
+            self.startNamingNewSave,
+        )
+        self.renderer.drawText(
+            "or press C",
+            xpos,
+            btnY + btnHeight + 22,
+            18,
+            palette.MEDIUM_GRAY,
         )
 
     def drawSaveList(self, saves):
@@ -603,7 +625,8 @@ class SaveSelectionScreen(Screen):
         self.drawTitle()
 
         saves = self.getSaveDirectories()
-        if len(saves) == 0:
+        hasSaves = len(saves) > 0
+        if not hasSaves:
             self.drawNoSavesMessage()
         else:
             self.drawSaveList(saves)
@@ -615,17 +638,15 @@ class SaveSelectionScreen(Screen):
         elif self.namingNewSave:
             self.drawNamingDialog()
         else:
-            self.drawControlsHint()
+            self.drawControlsHint(hasSaves)
 
-    def drawControlsHint(self):
+    def drawControlsHint(self, hasSaves=True):
         x, y = self.renderer.getDisplaySize()
-        self.renderer.drawText(
-            "Up/Down: choose  -  Enter: play  -  C: new  -  Bksp: delete  -  T: sort  -  Esc: back",
-            x / 2,
-            y - 14,
-            16,
-            palette.MEDIUM_GRAY,
-        )
+        if hasSaves:
+            hint = "W/S or Up/Down: choose  -  Enter: play  -  C: new  -  Bksp: delete  -  T: sort  -  Esc: back"
+        else:
+            hint = "C or click button: create new save  -  Esc: back"
+        self.renderer.drawText(hint, x / 2, y - 14, 16, palette.MEDIUM_GRAY)
 
     def onExit(self):
         if self.nextScreen == ScreenType.WORLD_SCREEN:

--- a/src/screen/worldScreen.py
+++ b/src/screen/worldScreen.py
@@ -590,12 +590,35 @@ class WorldScreen:
         else:
             self.status.set("Nothing notable ahead")
 
+    def _locationHasSomethingToGather(self, location):
+        """Return True if _executeGatherAt would find something at this location."""
+        if location == -1:
+            return False
+        for entityId in location.getEntities():
+            entity = location.getEntity(entityId)
+            if isinstance(entity, (YoungCrop, MatureCrop)):
+                return True
+            if self.canBePickedUp(entity):
+                return True
+            if (
+                isinstance(entity, Chest)
+                and entity.getStoredInventory().getNumItems() > 0
+            ):
+                return True
+        return False
+
     def executeGatherAtFront(self):
-        targetLocation = self.getLocationInFrontOfPlayer()
-        if targetLocation == -1:
+        facingLocation = self.getLocationInFrontOfPlayer()
+        if self._locationHasSomethingToGather(facingLocation):
+            self._executeGatherAt(facingLocation, self.currentRoom)
+            return
+        # Nothing pickable in front — try the player's own tile so items
+        # on the same cell can be picked up without needing to face away.
+        playerLocation = self.getLocationOfPlayer()
+        if playerLocation == -1:
             self.status.set("Nothing to pick up here")
             return
-        self._executeGatherAt(targetLocation, self.currentRoom)
+        self._executeGatherAt(playerLocation, self.currentRoom)
 
     def _executeGatherAt(self, targetLocation, targetRoom):
         if self._tryHarvestCrop(targetLocation, targetRoom):
@@ -1761,6 +1784,15 @@ class WorldScreen:
             hintX = self.renderer.getDisplayWidth() - 50
             hintY = self.renderer.getDisplayHeight() - 20
             self.renderer.drawText(hintLabel, hintX, hintY, 16, palette.MEDIUM_GRAY)
+
+            if not self.renderer.supportsImageLoading():
+                kb = self.keyBindings
+                gatherKey = kb.getKeyName("gather").upper()
+                placeKey = kb.getKeyName("place").upper()
+                actionHint = f"{gatherKey}: Gather  {placeKey}: Place"
+                self.renderer.drawTextLeftAligned(
+                    actionHint, 0, hintY, 16, palette.MEDIUM_GRAY
+                )
 
         self.drawCursorSlot()
 

--- a/tests/screen/test_worldScreen_gatherPlace_atFront.py
+++ b/tests/screen/test_worldScreen_gatherPlace_atFront.py
@@ -65,6 +65,8 @@ def _makeWorldScreen(room=None):
 def test_gather_at_front_no_location_sets_status():
     ws = _makeWorldScreen()
     ws.getLocationInFrontOfPlayer = lambda: -1
+    # Both the facing tile and the player's own tile are absent.
+    ws.getLocationOfPlayer = lambda: -1
 
     ws.executeGatherAtFront()
 
@@ -93,12 +95,34 @@ def test_gather_at_front_sets_nothing_to_pick_up_when_empty():
     ws = _makeWorldScreen(room)
 
     emptyLoc = room.getGrid().getLocationByCoordinates(2, 2)
+    playerLoc = room.getGrid().getLocationByCoordinates(1, 1)
     ws.getLocationInFrontOfPlayer = lambda: emptyLoc
+    # Player's own tile is also empty — final fallback shows nothing message.
+    ws.getLocationOfPlayer = lambda: playerLoc
     ws._tryHarvestCrop = lambda loc, r: False
 
     ws.executeGatherAtFront()
 
     ws.status.set.assert_called_with("Nothing to pick up here")
+
+
+def test_gather_at_front_falls_back_to_player_tile_when_facing_empty():
+    room = _makeRoom(gridSize=5)
+    ws = _makeWorldScreen(room)
+
+    apple = Apple()
+    playerLoc = room.getGrid().getLocationByCoordinates(1, 1)
+    room.addEntityToLocation(apple, playerLoc)
+
+    emptyFacingLoc = room.getGrid().getLocationByCoordinates(2, 2)
+    ws.getLocationInFrontOfPlayer = lambda: emptyFacingLoc
+    ws.getLocationOfPlayer = lambda: playerLoc
+    ws._tryHarvestCrop = lambda loc, r: False
+
+    ws.executeGatherAtFront()
+
+    assert ws.player.getInventory().getNumItems() == 1
+    ws.status.set.assert_called_with("Picked up " + apple.getName())
 
 
 def test_gather_at_front_full_inventory_sets_status():


### PR DESCRIPTION
## Summary

- **Same-tile item pickup** — `G` now falls back to the player's own tile when the facing tile has nothing to gather. Previously you had to face away from yourself to pick up items you were standing on.
- **Text-mode gather hint** — Added `G: Gather  F: Place` hint at the bottom-left of the world screen in text/TUI mode, where the HUD action icons aren't visible.
- **Button click debounce** — `graphik.drawButton` now fires only on the leading-edge (down-transition) of a mouse press, preventing repeated firing while a button is held down.
- **WASD menu navigation** — `W`/`S` now move the cursor in the Main Menu, Save Selection, and Controls screens alongside the existing arrow keys.
- **New-save discoverability** — When no saves exist, the Save Selection screen now shows a prominent green "Create New Save" button (with `or press C` fallback) instead of bare instructional text.

## Test plan

- [ ] Run `python3 -m pytest tests/ -q` — all 919 tests pass
- [ ] Run `python3 -m black --check src tests` — no formatting violations
- [ ] In pygame mode: verify single-click on menu buttons fires once (no repeat while held)
- [ ] In pygame mode: verify W/S navigate Main Menu, Save Selection, Controls
- [ ] In pygame mode: launch with no saves — confirm green "Create New Save" button appears
- [ ] In text mode (`--text`): verify `G: Gather  F: Place` hint appears at bottom-left of world screen
- [ ] Stand on a tile with an item, face an empty tile, press G — item should be picked up from player tile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_