### PR TITLE
feat: accept any wood type in recipes + readable ingredient names

### DIFF
--- a/src/crafting/recipeRegistry.py
+++ b/src/crafting/recipeRegistry.py
@@ -5,13 +5,12 @@ from entity.chest import Chest
 from entity.coalOre import CoalOre
 from entity.fence import Fence
 from entity.grass import Grass
-from entity.jungleWood import JungleWood
-from entity.oakWood import OakWood
 from entity.stone import Stone
 from entity.stoneBed import StoneBed
 from entity.stoneFloor import StoneFloor
 from entity.torch import Torch
 from entity.wheatSeed import WheatSeed
+from entity.wood import Wood
 from entity.woodFloor import WoodFloor
 
 
@@ -23,7 +22,7 @@ class RecipeRegistry:
         self.recipes.append(
             Recipe(
                 "Wood Floor",
-                {OakWood: 4},
+                {Wood: 4},
                 WoodFloor,
                 "assets/images/woodFloor.png",
             )
@@ -31,7 +30,7 @@ class RecipeRegistry:
         self.recipes.append(
             Recipe(
                 "Bed",
-                {OakWood: 3, Stone: 2},
+                {Wood: 3, Stone: 2},
                 Bed,
                 "assets/images/bed.png",
             )
@@ -47,7 +46,7 @@ class RecipeRegistry:
         self.recipes.append(
             Recipe(
                 "Stone Bed",
-                {Stone: 3, OakWood: 2},
+                {Stone: 3, Wood: 2},
                 StoneBed,
                 "assets/images/stoneBed.png",
             )
@@ -55,7 +54,7 @@ class RecipeRegistry:
         self.recipes.append(
             Recipe(
                 "Fence",
-                {JungleWood: 3},
+                {Wood: 3},
                 Fence,
                 "assets/images/fence.png",
             )
@@ -63,7 +62,7 @@ class RecipeRegistry:
         self.recipes.append(
             Recipe(
                 "Campfire",
-                {OakWood: 2, CoalOre: 1},
+                {Wood: 2, CoalOre: 1},
                 Campfire,
                 "assets/images/campfire.png",
             )
@@ -71,7 +70,7 @@ class RecipeRegistry:
         self.recipes.append(
             Recipe(
                 "Chest",
-                {OakWood: 6},
+                {Wood: 6},
                 Chest,
                 "assets/images/chest.png",
             )
@@ -88,7 +87,7 @@ class RecipeRegistry:
         self.recipes.append(
             Recipe(
                 "Torch",
-                {OakWood: 1, CoalOre: 1},
+                {Wood: 1, CoalOre: 1},
                 Torch,
                 "assets/images/torch.png",
                 2,

--- a/src/entity/jungleWood.py
+++ b/src/entity/jungleWood.py
@@ -1,10 +1,8 @@
-from entity.drawableEntity import DrawableEntity
+from entity.wood import Wood
 
 
 # @author Daniel McCoy Stephenson
 # @since August 8th, 2022
-class JungleWood(DrawableEntity):
+class JungleWood(Wood):
     def __init__(self):
-        DrawableEntity.__init__(
-            self, "Jungle Wood", "assets/images/jungleWood.png", True
-        )
+        Wood.__init__(self, "Jungle Wood", "assets/images/jungleWood.png", True)

--- a/src/entity/oakWood.py
+++ b/src/entity/oakWood.py
@@ -1,8 +1,8 @@
-from entity.drawableEntity import DrawableEntity
+from entity.wood import Wood
 
 
 # @author Daniel McCoy Stephenson
 # @since August 8th, 2022
-class OakWood(DrawableEntity):
+class OakWood(Wood):
     def __init__(self):
-        DrawableEntity.__init__(self, "Oak Wood", "assets/images/oakWood.png", True)
+        Wood.__init__(self, "Oak Wood", "assets/images/oakWood.png", True)

--- a/src/entity/wood.py
+++ b/src/entity/wood.py
@@ -1,0 +1,6 @@
+from entity.drawableEntity import DrawableEntity
+
+
+# @author Daniel McCoy Stephenson
+class Wood(DrawableEntity):
+    pass

--- a/src/screen/inventoryScreen.py
+++ b/src/screen/inventoryScreen.py
@@ -1,3 +1,4 @@
+import re
 import time
 from appContainer import component
 from config.config import Config
@@ -336,6 +337,10 @@ class InventoryScreen(Screen):
         recipeButtonHeight = max(20, rowStride - recipeMargin)
         return startY, rowStride, recipeButtonHeight, recipeMargin
 
+    @staticmethod
+    def _ingredientLabel(cls):
+        return re.sub(r"(?<=[a-z])(?=[A-Z])", " ", cls.__name__)
+
     def drawCraftPanel(self):
         if not self.craftPanelOpen:
             return
@@ -370,7 +375,7 @@ class InventoryScreen(Screen):
             recipeY = startY + i * rowStride
             ingredientText = ", ".join(
                 [
-                    str(count) + "x " + cls.__name__
+                    str(count) + "x " + self._ingredientLabel(cls)
                     for cls, count in recipe.getIngredients().items()
                 ]
             )
@@ -393,7 +398,7 @@ class InventoryScreen(Screen):
                 )
             else:
                 missingParts = [
-                    f"{required - self.inventory.getNumItemsByType(cls)} {cls.__name__}"
+                    f"{required - self.inventory.getNumItemsByType(cls)} {self._ingredientLabel(cls)}"
                     for cls, required in recipe.getIngredients().items()
                     if self.inventory.getNumItemsByType(cls) < required
                 ]

--- a/tests/crafting/test_recipe.py
+++ b/tests/crafting/test_recipe.py
@@ -1,15 +1,33 @@
 from src.crafting.recipe import Recipe
 from src.entity.bed import Bed
+from src.entity.jungleWood import JungleWood
 from src.entity.oakWood import OakWood
 from src.entity.stone import Stone
 from src.entity.woodFloor import WoodFloor
 from src.inventory.inventory import Inventory
+from entity.wood import Wood  # import via the same path the production code uses
 
 
 def createInventoryWithOakWood(count):
     inventory = Inventory()
     for i in range(count):
         inventory.placeIntoFirstAvailableInventorySlot(OakWood())
+    return inventory
+
+
+def createInventoryWithJungleWood(count):
+    inventory = Inventory()
+    for i in range(count):
+        inventory.placeIntoFirstAvailableInventorySlot(JungleWood())
+    return inventory
+
+
+def createInventoryWithMixedWood(oakCount, jungleCount):
+    inventory = Inventory()
+    for i in range(oakCount):
+        inventory.placeIntoFirstAvailableInventorySlot(OakWood())
+    for i in range(jungleCount):
+        inventory.placeIntoFirstAvailableInventorySlot(JungleWood())
     return inventory
 
 
@@ -24,58 +42,71 @@ def createInventoryWithOakWoodAndStone(oakCount, stoneCount):
 
 def test_canCraft_returns_true_when_materials_present():
     inventory = createInventoryWithOakWood(4)
-    recipe = Recipe(
-        "Wood Floor", {OakWood: 4}, WoodFloor, "assets/images/woodFloor.png"
-    )
+    recipe = Recipe("Wood Floor", {Wood: 4}, WoodFloor, "assets/images/woodFloor.png")
     assert recipe.canCraft(inventory) is True
 
 
 def test_canCraft_returns_false_when_materials_missing():
     inventory = createInventoryWithOakWood(2)
-    recipe = Recipe(
-        "Wood Floor", {OakWood: 4}, WoodFloor, "assets/images/woodFloor.png"
-    )
+    recipe = Recipe("Wood Floor", {Wood: 4}, WoodFloor, "assets/images/woodFloor.png")
     assert recipe.canCraft(inventory) is False
+
+
+def test_canCraft_jungle_wood_satisfies_wood_ingredient():
+    inventory = createInventoryWithJungleWood(4)
+    recipe = Recipe("Wood Floor", {Wood: 4}, WoodFloor, "assets/images/woodFloor.png")
+    assert recipe.canCraft(inventory) is True
+
+
+def test_canCraft_mixed_wood_satisfies_wood_ingredient():
+    inventory = createInventoryWithMixedWood(2, 2)
+    recipe = Recipe("Wood Floor", {Wood: 4}, WoodFloor, "assets/images/woodFloor.png")
+    assert recipe.canCraft(inventory) is True
 
 
 def test_craft_deducts_materials_and_returns_item():
     inventory = createInventoryWithOakWood(4)
-    recipe = Recipe(
-        "Wood Floor", {OakWood: 4}, WoodFloor, "assets/images/woodFloor.png"
-    )
+    recipe = Recipe("Wood Floor", {Wood: 4}, WoodFloor, "assets/images/woodFloor.png")
     result = recipe.craft(inventory)
     assert result is not None
     assert len(result) == 1
     assert isinstance(result[0], WoodFloor)
-    assert inventory.getNumItemsByType(OakWood) == 0
+    assert inventory.getNumItemsByType(Wood) == 0
+
+
+def test_craft_jungle_wood_deducts_and_returns_item():
+    inventory = createInventoryWithJungleWood(4)
+    recipe = Recipe("Wood Floor", {Wood: 4}, WoodFloor, "assets/images/woodFloor.png")
+    result = recipe.craft(inventory)
+    assert result is not None
+    assert isinstance(result[0], WoodFloor)
+    assert inventory.getNumItemsByType(Wood) == 0
 
 
 def test_craft_returns_none_when_materials_missing():
     inventory = createInventoryWithOakWood(2)
-    recipe = Recipe(
-        "Wood Floor", {OakWood: 4}, WoodFloor, "assets/images/woodFloor.png"
-    )
+    recipe = Recipe("Wood Floor", {Wood: 4}, WoodFloor, "assets/images/woodFloor.png")
     result = recipe.craft(inventory)
     assert result is None
-    assert inventory.getNumItemsByType(OakWood) == 2
+    assert inventory.getNumItemsByType(Wood) == 2
 
 
 def test_craft_multi_ingredient_deducts_each_type():
     inventory = createInventoryWithOakWoodAndStone(3, 2)
-    recipe = Recipe("Bed", {OakWood: 3, Stone: 2}, Bed, "assets/images/bed.png")
+    recipe = Recipe("Bed", {Wood: 3, Stone: 2}, Bed, "assets/images/bed.png")
     result = recipe.craft(inventory)
     assert result is not None
     assert len(result) == 1
     assert isinstance(result[0], Bed)
-    assert inventory.getNumItemsByType(OakWood) == 0
+    assert inventory.getNumItemsByType(Wood) == 0
     assert inventory.getNumItemsByType(Stone) == 0
 
 
 def test_craft_multi_ingredient_consumes_only_required_counts():
     inventory = createInventoryWithOakWoodAndStone(5, 4)
-    recipe = Recipe("Bed", {OakWood: 3, Stone: 2}, Bed, "assets/images/bed.png")
+    recipe = Recipe("Bed", {Wood: 3, Stone: 2}, Bed, "assets/images/bed.png")
     result = recipe.craft(inventory)
     assert result is not None
     assert isinstance(result[0], Bed)
-    assert inventory.getNumItemsByType(OakWood) == 2
+    assert inventory.getNumItemsByType(Wood) == 2
     assert inventory.getNumItemsByType(Stone) == 2

--- a/tests/crafting/test_recipeRegistry.py
+++ b/tests/crafting/test_recipeRegistry.py
@@ -1,4 +1,7 @@
 from src.crafting.recipeRegistry import RecipeRegistry
+from entity.coalOre import CoalOre
+from entity.stone import Stone
+from entity.wood import Wood
 
 
 def test_recipeRegistry_has_wood_floor_recipe():
@@ -8,8 +11,7 @@ def test_recipeRegistry_has_wood_floor_recipe():
     assert len(woodFloorRecipes) == 1
     recipe = woodFloorRecipes[0]
     ingredients = recipe.getIngredients()
-    ingredientNames = {cls.__name__: count for cls, count in ingredients.items()}
-    assert ingredientNames == {"OakWood": 4}
+    assert ingredients == {Wood: 4}
 
 
 def test_recipeRegistry_has_bed_recipe():
@@ -19,8 +21,7 @@ def test_recipeRegistry_has_bed_recipe():
     assert len(bedRecipes) == 1
     recipe = bedRecipes[0]
     ingredients = recipe.getIngredients()
-    ingredientNames = {cls.__name__: count for cls, count in ingredients.items()}
-    assert ingredientNames == {"OakWood": 3, "Stone": 2}
+    assert ingredients == {Wood: 3, Stone: 2}
 
 
 def test_recipeRegistry_has_stone_floor_recipe():
@@ -30,8 +31,7 @@ def test_recipeRegistry_has_stone_floor_recipe():
     assert len(stoneFloorRecipes) == 1
     recipe = stoneFloorRecipes[0]
     ingredients = recipe.getIngredients()
-    ingredientNames = {cls.__name__: count for cls, count in ingredients.items()}
-    assert ingredientNames == {"Stone": 4}
+    assert ingredients == {Stone: 4}
 
 
 def test_recipeRegistry_has_stone_bed_recipe():
@@ -41,8 +41,7 @@ def test_recipeRegistry_has_stone_bed_recipe():
     assert len(stoneBedRecipes) == 1
     recipe = stoneBedRecipes[0]
     ingredients = recipe.getIngredients()
-    ingredientNames = {cls.__name__: count for cls, count in ingredients.items()}
-    assert ingredientNames == {"Stone": 3, "OakWood": 2}
+    assert ingredients == {Stone: 3, Wood: 2}
 
 
 def test_recipeRegistry_has_fence_recipe():
@@ -52,8 +51,7 @@ def test_recipeRegistry_has_fence_recipe():
     assert len(fenceRecipes) == 1
     recipe = fenceRecipes[0]
     ingredients = recipe.getIngredients()
-    ingredientNames = {cls.__name__: count for cls, count in ingredients.items()}
-    assert ingredientNames == {"JungleWood": 3}
+    assert ingredients == {Wood: 3}
 
 
 def test_recipeRegistry_has_campfire_recipe():
@@ -63,8 +61,7 @@ def test_recipeRegistry_has_campfire_recipe():
     assert len(campfireRecipes) == 1
     recipe = campfireRecipes[0]
     ingredients = recipe.getIngredients()
-    ingredientNames = {cls.__name__: count for cls, count in ingredients.items()}
-    assert ingredientNames == {"OakWood": 2, "CoalOre": 1}
+    assert ingredients == {Wood: 2, CoalOre: 1}
 
 
 def test_recipeRegistry_has_chest_recipe():
@@ -74,5 +71,4 @@ def test_recipeRegistry_has_chest_recipe():
     assert len(chestRecipes) == 1
     recipe = chestRecipes[0]
     ingredients = recipe.getIngredients()
-    ingredientNames = {cls.__name__: count for cls, count in ingredients.items()}
-    assert ingredientNames == {"OakWood": 6}
+    assert ingredients == {Wood: 6}

--- a/tests/crafting/test_torchRecipe.py
+++ b/tests/crafting/test_torchRecipe.py
@@ -1,4 +1,6 @@
 from src.crafting.recipeRegistry import RecipeRegistry
+from entity.coalOre import CoalOre
+from entity.wood import Wood
 
 
 def test_recipeRegistry_has_torch_recipe():
@@ -8,6 +10,5 @@ def test_recipeRegistry_has_torch_recipe():
     assert len(torchRecipes) == 1
     recipe = torchRecipes[0]
     ingredients = recipe.getIngredients()
-    ingredientNames = {cls.__name__: count for cls, count in ingredients.items()}
-    assert ingredientNames == {"OakWood": 1, "CoalOre": 1}
+    assert ingredients == {Wood: 1, CoalOre: 1}
     assert recipe.getResultCount() == 2


### PR DESCRIPTION
## Summary

- Adds a `Wood` base class (`src/entity/wood.py`) that both `OakWood` and `JungleWood` inherit from, making them interchangeable in all crafting recipes
- All 7 wood-requiring recipes (Wood Floor, Bed, Stone Bed, Fence, Campfire, Chest, Torch) now use `Wood` as the ingredient type — oak and jungle wood can be mixed in a single craft
- Fixes craft panel ingredient display: PascalCase class names are now converted to human-readable labels (`CoalOre` → `Coal Ore`, `OakWood` → `Oak Wood`, `Wood` → `Wood`)

## Test plan

- [ ] Craft a Wood Floor using only Jungle Wood
- [ ] Craft a Bed using a mix of Oak and Jungle Wood
- [ ] Confirm craft panel shows "Wood" and "Coal Ore" (not "OakWood", "CoalOre") in recipe labels and missing-ingredient hints
- [ ] `python3 -m pytest tests/crafting/ tests/rendering/ tests/config/ tests/screen/ tests/ui/ -q` — all 520 pass
- [ ] `python3 -m black --check src tests` — no formatting violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_