### PR TITLE
feat: browser-playable web frontend via --web flag

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ pygame>=2.6.1
 Pillow>=10.0.0
 jsonschema>=4.17.3
 structlog>=25.0.0
+websockets>=12.0
 
 # Test
 pytest>=7.1.3

--- a/src/rendering/webFrontend.py
+++ b/src/rendering/webFrontend.py
@@ -70,6 +70,13 @@ class WebSession:
                         t == "mouse_down",
                     )
                     return
+
+                if t == "mouse_move":
+                    self._inputSource.moveMouse(
+                        int(msg.get("x", 0)),
+                        int(msg.get("y", 0)),
+                    )
+                    return
             except (json.JSONDecodeError, KeyError, ValueError):
                 pass
 

--- a/src/rendering/webFrontend.py
+++ b/src/rendering/webFrontend.py
@@ -2,11 +2,17 @@ import asyncio
 import functools
 import http.server
 import os
+import re
 import threading
 
+from rendering.inputEvent import EventType, InputEvent
 from rendering.textClock import TextClock
 from rendering.webInputSource import WebInputSource
 from rendering.webRenderer import WebRenderer, _DEFAULT_COLUMNS, _DEFAULT_ROWS
+
+# CSI 8 ; <rows> ; <cols> t  — the standard xterm window-resize report that
+# xterm-addon-fit sends to tell the server its computed terminal dimensions.
+_RESIZE_RE = re.compile(r"\x1b\[8;(\d+);(\d+)t")
 
 _DEFAULT_WS_PORT = 8765
 _DEFAULT_HTTP_PORT = 8080
@@ -38,6 +44,20 @@ class WebSession:
         asyncio.run_coroutine_threadsafe(self._sendQueue.put(data), self._loop)
 
     def feedInput(self, data):
+        # Intercept the xterm resize report (CSI 8 ; rows ; cols t) before it
+        # reaches the ANSI key parser — it's a terminal control sequence, not a
+        # keystroke.  The renderer's resize() forces a full redraw at the new size.
+        m = _RESIZE_RE.fullmatch(data.strip())
+        if m:
+            rows, cols = int(m.group(1)), int(m.group(2))
+            if cols > 0 and rows > 0:
+                self._renderer.resize(cols, rows)
+                # Mirror what TextFrontend does on SIGWINCH: queue a WINDOW_RESIZE
+                # event so screens recalculate their pixel layout for the new size.
+                self._inputSource.queueEvent(
+                    InputEvent(EventType.WINDOW_RESIZE, size=(cols, rows))
+                )
+            return
         self._inputSource.feed(data)
 
     # --- Frontend interface (mirrors PygameFrontend / TextFrontend) ---

--- a/src/rendering/webFrontend.py
+++ b/src/rendering/webFrontend.py
@@ -3,17 +3,12 @@ import functools
 import http.server
 import json
 import os
-import re
 import threading
 
 from rendering.inputEvent import EventType, InputEvent
 from rendering.textClock import TextClock
 from rendering.webInputSource import WebInputSource
-from rendering.webRenderer import WebRenderer, _DEFAULT_COLUMNS, _DEFAULT_ROWS
-
-# CSI 8 ; <rows> ; <cols> t  — the standard xterm window-resize report that
-# xterm-addon-fit sends to tell the server its computed terminal dimensions.
-_RESIZE_RE = re.compile(r"\x1b\[8;(\d+);(\d+)t")
+from rendering.webRenderer import WebRenderer, _DEFAULT_WIDTH, _DEFAULT_HEIGHT
 
 _DEFAULT_WS_PORT = 8765
 _DEFAULT_HTTP_PORT = 8080
@@ -25,9 +20,16 @@ _DEFAULT_HTTP_PORT = 8080
 # Per-connection frontend: owns one WebRenderer + WebInputSource + TextClock for
 # a single browser session.  Implements the same interface as PygameFrontend /
 # TextFrontend (getRenderer, getInputSource, getClock, setCaption, reset, quit)
-# so Roam.__init__ can accept it as a drop-in frontend.  Thread-safe I/O is
-# handled by _enqueueFrame (game thread → asyncio send queue) and feed()
-# (asyncio receive → input queue).
+# so Roam.__init__ can accept it as a drop-in frontend.
+#
+# Input protocol (browser → server, all messages are JSON strings):
+#   {"type":"resize",    "w":800, "h":600}         — viewport size changed
+#   {"type":"mouse_down","x":320,"y":240,"button":1} — tap / left-click
+#   {"type":"mouse_up",  "x":320,"y":240,"button":1} — release
+#   raw ANSI bytes (e.g. "\x1b[A" for ↑, "g" for gather) — keyboard / D-pad
+#
+# Output protocol (server → browser):
+#   JSON frame: {"type":"frame","w":W,"h":H,"calls":[{op,…},…]}
 class WebSession:
     def __init__(self, websocket, loop):
         self._websocket = websocket
@@ -45,24 +47,21 @@ class WebSession:
         asyncio.run_coroutine_threadsafe(self._sendQueue.put(data), self._loop)
 
     def feedInput(self, data):
-        # --- resize report (CSI 8 ; rows ; cols t) ---
-        m = _RESIZE_RE.fullmatch(data.strip())
-        if m:
-            rows, cols = int(m.group(1)), int(m.group(2))
-            if cols > 0 and rows > 0:
-                self._renderer.resize(cols, rows)
-                # Mirror what TextFrontend does on SIGWINCH: queue a WINDOW_RESIZE
-                # event so screens recalculate their pixel layout for the new size.
-                self._inputSource.queueEvent(
-                    InputEvent(EventType.WINDOW_RESIZE, size=(cols, rows))
-                )
-            return
-
-        # --- JSON mouse event {"type":"mouse_down"|"mouse_up","x":…,"y":…,"button":…} ---
+        # --- JSON control messages (resize, mouse) ---
         if data.startswith("{"):
             try:
                 msg = json.loads(data)
                 t = msg.get("type")
+
+                if t == "resize":
+                    w, h = int(msg.get("w", 0)), int(msg.get("h", 0))
+                    if w > 0 and h > 0:
+                        self._renderer.resize(w, h)
+                        self._inputSource.queueEvent(
+                            InputEvent(EventType.WINDOW_RESIZE, size=(w, h))
+                        )
+                    return
+
                 if t in ("mouse_down", "mouse_up"):
                     self._inputSource.updateMouse(
                         int(msg.get("x", 0)),
@@ -74,6 +73,7 @@ class WebSession:
             except (json.JSONDecodeError, KeyError, ValueError):
                 pass
 
+        # --- ANSI key sequences from keyboard / on-screen buttons ---
         self._inputSource.feed(data)
 
     # --- Frontend interface (mirrors PygameFrontend / TextFrontend) ---
@@ -88,11 +88,9 @@ class WebSession:
         return self._clock
 
     def setCaption(self, caption):
-        self._renderer.setCaption(caption)
+        pass
 
     def reset(self):
-        # Rebuild renderer/input for a fresh game session (return-to-main-menu),
-        # keeping the same _enqueueFrame callback so the WebSocket is unchanged.
         self._build()
 
     def quit(self):
@@ -126,21 +124,14 @@ class WebSession:
 # @since June 27th, 2026
 #
 # WebSocket game server.  serve(gameFactory) starts two listeners:
-#   - HTTP on httpPort: serves web/index.html so players can open a browser URL.
+#   - HTTP on httpPort: serves web/index.html + game assets (assets/ dir)
 #   - WebSocket on wsPort: each connection spawns a WebSession + a game thread.
-#
-# gameFactory(session) is called in a daemon thread per connection; it should
-# run the full Roam game loop and return (or raise SystemExit) when the session
-# ends.  Multiple concurrent sessions are supported — each gets its own
-# independent game state.
 class WebFrontend:
     def __init__(self, wsPort=_DEFAULT_WS_PORT, httpPort=_DEFAULT_HTTP_PORT):
         self._wsPort = wsPort
         self._httpPort = httpPort
 
     def serve(self, gameFactory):
-        """Block until Ctrl+C, accepting WebSocket connections and running a
-        game session per connection."""
         try:
             asyncio.run(self._serveAsync(gameFactory))
         except KeyboardInterrupt:
@@ -183,22 +174,44 @@ class WebFrontend:
 
 
 def _startHttpServer(port):
-    """Serve web/ over HTTP on a background daemon thread."""
+    """Serve web/index.html + game assets (assets/) over HTTP.
+
+    Routes:
+      /            → web/index.html
+      /index.html  → web/index.html
+      /assets/...  → <projectRoot>/assets/...   (tile sprites etc.)
+      anything else → 404
+    """
     webDir = os.path.normpath(
         os.path.join(os.path.dirname(__file__), "..", "..", "web")
     )
+    rootDir = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", ".."))
 
-    class _QuietHandler(http.server.SimpleHTTPRequestHandler):
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, directory=webDir, **kwargs)
+    # Closure-based handler so webDir / rootDir are captured without needing
+    # instance state on the handler class.
+    def _makeHandler(webDir, rootDir):
+        class _Handler(http.server.SimpleHTTPRequestHandler):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, directory=rootDir, **kwargs)
 
-        def log_message(self, format, *args):
-            pass
+            def translate_path(self, path):
+                from urllib.parse import unquote, urlparse
+
+                path = unquote(urlparse(path).path)
+                if path in ("/", "/index.html"):
+                    return os.path.join(webDir, "index.html")
+                # /assets/... served directly from project root
+                return super().translate_path(path)
+
+            def log_message(self, *args):
+                pass
+
+        return _Handler
 
     class _ReuseServer(http.server.HTTPServer):
         allow_reuse_address = True
 
-    httpd = _ReuseServer(("", port), _QuietHandler)
+    httpd = _ReuseServer(("", port), _makeHandler(webDir, rootDir))
     threading.Thread(target=httpd.serve_forever, daemon=True).start()
     return httpd
 

--- a/src/rendering/webFrontend.py
+++ b/src/rendering/webFrontend.py
@@ -1,6 +1,7 @@
 import asyncio
 import functools
 import http.server
+import json
 import os
 import re
 import threading
@@ -44,9 +45,7 @@ class WebSession:
         asyncio.run_coroutine_threadsafe(self._sendQueue.put(data), self._loop)
 
     def feedInput(self, data):
-        # Intercept the xterm resize report (CSI 8 ; rows ; cols t) before it
-        # reaches the ANSI key parser — it's a terminal control sequence, not a
-        # keystroke.  The renderer's resize() forces a full redraw at the new size.
+        # --- resize report (CSI 8 ; rows ; cols t) ---
         m = _RESIZE_RE.fullmatch(data.strip())
         if m:
             rows, cols = int(m.group(1)), int(m.group(2))
@@ -58,6 +57,23 @@ class WebSession:
                     InputEvent(EventType.WINDOW_RESIZE, size=(cols, rows))
                 )
             return
+
+        # --- JSON mouse event {"type":"mouse_down"|"mouse_up","x":…,"y":…,"button":…} ---
+        if data.startswith("{"):
+            try:
+                msg = json.loads(data)
+                t = msg.get("type")
+                if t in ("mouse_down", "mouse_up"):
+                    self._inputSource.updateMouse(
+                        int(msg.get("x", 0)),
+                        int(msg.get("y", 0)),
+                        int(msg.get("button", 1)),
+                        t == "mouse_down",
+                    )
+                    return
+            except (json.JSONDecodeError, KeyError, ValueError):
+                pass
+
         self._inputSource.feed(data)
 
     # --- Frontend interface (mirrors PygameFrontend / TextFrontend) ---

--- a/src/rendering/webFrontend.py
+++ b/src/rendering/webFrontend.py
@@ -37,8 +37,8 @@ class WebSession:
 
     def _build(self):
         self._sendQueue = asyncio.Queue()
-        self._renderer = WebRenderer(self._enqueueFrame)
         self._inputSource = WebInputSource()
+        self._renderer = WebRenderer(self._enqueueFrame, inputSource=self._inputSource)
         self._clock = TextClock()
 
     def _enqueueFrame(self, data):

--- a/src/rendering/webFrontend.py
+++ b/src/rendering/webFrontend.py
@@ -1,0 +1,171 @@
+import asyncio
+import functools
+import http.server
+import os
+import threading
+
+from rendering.textClock import TextClock
+from rendering.webInputSource import WebInputSource
+from rendering.webRenderer import WebRenderer, _DEFAULT_COLUMNS, _DEFAULT_ROWS
+
+_DEFAULT_WS_PORT = 8765
+_DEFAULT_HTTP_PORT = 8080
+
+
+# @author Daniel McCoy Stephenson
+# @since June 27th, 2026
+#
+# Per-connection frontend: owns one WebRenderer + WebInputSource + TextClock for
+# a single browser session.  Implements the same interface as PygameFrontend /
+# TextFrontend (getRenderer, getInputSource, getClock, setCaption, reset, quit)
+# so Roam.__init__ can accept it as a drop-in frontend.  Thread-safe I/O is
+# handled by _enqueueFrame (game thread → asyncio send queue) and feed()
+# (asyncio receive → input queue).
+class WebSession:
+    def __init__(self, websocket, loop):
+        self._websocket = websocket
+        self._loop = loop
+        self._stopped = threading.Event()
+        self._build()
+
+    def _build(self):
+        self._sendQueue = asyncio.Queue()
+        self._renderer = WebRenderer(self._enqueueFrame)
+        self._inputSource = WebInputSource()
+        self._clock = TextClock()
+
+    def _enqueueFrame(self, data):
+        asyncio.run_coroutine_threadsafe(self._sendQueue.put(data), self._loop)
+
+    def feedInput(self, data):
+        self._inputSource.feed(data)
+
+    # --- Frontend interface (mirrors PygameFrontend / TextFrontend) ---
+
+    def getRenderer(self):
+        return self._renderer
+
+    def getInputSource(self):
+        return self._inputSource
+
+    def getClock(self):
+        return self._clock
+
+    def setCaption(self, caption):
+        self._renderer.setCaption(caption)
+
+    def reset(self):
+        # Rebuild renderer/input for a fresh game session (return-to-main-menu),
+        # keeping the same _enqueueFrame callback so the WebSocket is unchanged.
+        self._build()
+
+    def quit(self):
+        self._stopped.set()
+        asyncio.run_coroutine_threadsafe(self._sendQueue.put(None), self._loop)
+
+    # --- Async I/O pump (runs on the event loop, not the game thread) ---
+
+    async def runIO(self):
+        async def _send():
+            while True:
+                data = await self._sendQueue.get()
+                if data is None:
+                    return
+                try:
+                    await self._websocket.send(data)
+                except Exception:
+                    return
+
+        async def _receive():
+            try:
+                async for message in self._websocket:
+                    self.feedInput(message)
+            except Exception:
+                pass
+
+        await asyncio.gather(_send(), _receive(), return_exceptions=True)
+
+
+# @author Daniel McCoy Stephenson
+# @since June 27th, 2026
+#
+# WebSocket game server.  serve(gameFactory) starts two listeners:
+#   - HTTP on httpPort: serves web/index.html so players can open a browser URL.
+#   - WebSocket on wsPort: each connection spawns a WebSession + a game thread.
+#
+# gameFactory(session) is called in a daemon thread per connection; it should
+# run the full Roam game loop and return (or raise SystemExit) when the session
+# ends.  Multiple concurrent sessions are supported — each gets its own
+# independent game state.
+class WebFrontend:
+    def __init__(self, wsPort=_DEFAULT_WS_PORT, httpPort=_DEFAULT_HTTP_PORT):
+        self._wsPort = wsPort
+        self._httpPort = httpPort
+
+    def serve(self, gameFactory):
+        """Block until Ctrl+C, accepting WebSocket connections and running a
+        game session per connection."""
+        try:
+            asyncio.run(self._serveAsync(gameFactory))
+        except KeyboardInterrupt:
+            pass
+
+    async def _serveAsync(self, gameFactory):
+        import websockets
+
+        _startHttpServer(self._httpPort)
+        print(f"Roam web server: http://localhost:{self._httpPort}/")
+        print(f"  (WebSocket on ws://localhost:{self._wsPort})")
+        print("Press Ctrl+C to stop.")
+
+        async def handler(websocket):
+            loop = asyncio.get_event_loop()
+            session = WebSession(websocket, loop)
+
+            def runGame():
+                try:
+                    gameFactory(session)
+                except (SystemExit, KeyboardInterrupt):
+                    pass
+                except Exception:
+                    import traceback
+
+                    traceback.print_exc()
+                finally:
+                    session.quit()
+
+            game_thread = threading.Thread(target=runGame, daemon=True)
+            game_thread.start()
+            await session.runIO()
+            game_thread.join(timeout=3.0)
+
+        async with websockets.serve(handler, "0.0.0.0", self._wsPort):
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                pass
+
+
+def _startHttpServer(port):
+    """Serve web/ over HTTP on a background daemon thread."""
+    webDir = os.path.normpath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "web")
+    )
+
+    class _QuietHandler(http.server.SimpleHTTPRequestHandler):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, directory=webDir, **kwargs)
+
+        def log_message(self, format, *args):
+            pass
+
+    class _ReuseServer(http.server.HTTPServer):
+        allow_reuse_address = True
+
+    httpd = _ReuseServer(("", port), _QuietHandler)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    return httpd
+
+
+def createWebFrontend(wsPort=_DEFAULT_WS_PORT, httpPort=_DEFAULT_HTTP_PORT):
+    return WebFrontend(wsPort=wsPort, httpPort=httpPort)

--- a/src/rendering/webInputSource.py
+++ b/src/rendering/webInputSource.py
@@ -30,6 +30,14 @@ class WebInputSource(TextInputSource):
         if data:
             self._inputQueue.put(data)
 
+    def consumeLeftClick(self):
+        """Clear the left-button-down state after a button callback fires.
+
+        Called by WebRenderer.drawButton() to prevent the same tap from
+        triggering the callback on every frame until the mouse_up arrives.
+        """
+        self._mouseButtons[0] = False
+
     def updateMouse(self, x, y, button, isDown):
         """Update mouse state and queue a MOUSE_DOWN or MOUSE_UP event.
 

--- a/src/rendering/webInputSource.py
+++ b/src/rendering/webInputSource.py
@@ -1,6 +1,7 @@
 import queue
 import time
 
+from rendering.inputEvent import EventType, InputEvent
 from rendering.textInputSource import TextInputSource
 
 
@@ -12,15 +13,42 @@ from rendering.textInputSource import TextInputSource
 # de-bounce) — the only difference is the char source: instead of os.read on
 # stdin, characters arrive via feed() from the WebSocket handler and are
 # buffered in a thread-safe queue.
+#
+# Unlike TextInputSource (which always returns (0,0) / all-False for mouse),
+# this class tracks real mouse state so the game's existing click handling
+# (gather on left-click, place on right-click, hotbar slot selection) works
+# when the browser sends tap/click events as JSON mouse messages.
 class WebInputSource(TextInputSource):
     def __init__(self):
         self._inputQueue = queue.Queue()
+        self._mousePos = (0, 0)
+        self._mouseButtons = [False, False, False]  # left, middle, right
         super().__init__(charReader=self._readFromQueue)
 
     def feed(self, data: str):
         """Deliver a burst of raw terminal bytes received from xterm.js."""
         if data:
             self._inputQueue.put(data)
+
+    def updateMouse(self, x, y, button, isDown):
+        """Update mouse state and queue a MOUSE_DOWN or MOUSE_UP event.
+
+        Called by WebSession when a JSON mouse message arrives from the browser.
+        button follows SDL convention: 1=left, 2=middle, 3=right.
+        Thread-safe under CPython's GIL via the parent's queueEvent().
+        """
+        self._mousePos = (x, y)
+        idx = button - 1
+        if 0 <= idx < 3:
+            self._mouseButtons[idx] = isDown
+        evtType = EventType.MOUSE_DOWN if isDown else EventType.MOUSE_UP
+        self.queueEvent(InputEvent(evtType, position=(x, y), button=button))
+
+    def getMousePosition(self):
+        return self._mousePos
+
+    def getMouseButtons(self):
+        return tuple(self._mouseButtons)
 
     def _readFromQueue(self):
         try:

--- a/src/rendering/webInputSource.py
+++ b/src/rendering/webInputSource.py
@@ -1,0 +1,32 @@
+import queue
+import time
+
+from rendering.textInputSource import TextInputSource
+
+
+# @author Daniel McCoy Stephenson
+# @since June 27th, 2026
+#
+# WebSocket implementation of InputSource (web-frontend epic). Reuses all of
+# TextInputSource's ANSI parsing (arrow keys, control chars, movement key
+# de-bounce) — the only difference is the char source: instead of os.read on
+# stdin, characters arrive via feed() from the WebSocket handler and are
+# buffered in a thread-safe queue.
+class WebInputSource(TextInputSource):
+    def __init__(self):
+        self._inputQueue = queue.Queue()
+        super().__init__(charReader=self._readFromQueue)
+
+    def feed(self, data: str):
+        """Deliver a burst of raw terminal bytes received from xterm.js."""
+        if data:
+            self._inputQueue.put(data)
+
+    def _readFromQueue(self):
+        try:
+            return self._inputQueue.get_nowait()
+        except queue.Empty:
+            # Pace the idle game loop the same way TextInputSource's select()
+            # timeout does — avoids a busy-spin when no input is pending.
+            time.sleep(0.02)
+            return ""

--- a/src/rendering/webInputSource.py
+++ b/src/rendering/webInputSource.py
@@ -52,6 +52,15 @@ class WebInputSource(TextInputSource):
         evtType = EventType.MOUSE_DOWN if isDown else EventType.MOUSE_UP
         self.queueEvent(InputEvent(evtType, position=(x, y), button=button))
 
+    def moveMouse(self, x, y):
+        """Update mouse position and queue a MOUSE_MOTION event.
+
+        Sets _mousePos before queuing so getMousePosition() returns the right
+        coords when the game loop processes the event (e.g. hudDragManager).
+        """
+        self._mousePos = (x, y)
+        self.queueEvent(InputEvent(EventType.MOUSE_MOTION, position=(x, y)))
+
     def getMousePosition(self):
         return self._mousePos
 

--- a/src/rendering/webRenderer.py
+++ b/src/rendering/webRenderer.py
@@ -1,56 +1,254 @@
-from rendering.textRenderer import TextRenderer, _buildDiff
+import json
 
-_DEFAULT_COLUMNS = 120
-_DEFAULT_ROWS = 36
+from rendering.renderer import Renderer
+from ui.geometry import Rect
+
+_DEFAULT_WIDTH = 800
+_DEFAULT_HEIGHT = 600
+
+
+class _OffscreenSurface:
+    """Dummy surface for offscreen render targets (minimap PNG generation).
+
+    Draw calls aimed at an offscreen surface are silently discarded.  The
+    minimap feature requires saveImage() + tryLoadImage() round-trips that
+    are no-ops in web mode, so rooms will generate without minimap tiles.
+    """
 
 
 # @author Daniel McCoy Stephenson
 # @since June 27th, 2026
 #
-# WebSocket implementation of Renderer (web-frontend epic). Inherits all of
-# TextRenderer's drawing logic unchanged; the main overrides are:
-#   - present(): sends the ANSI diff to the browser via a thread-safe callback
-#   - drawButton(): mirrors PygameRenderer's hit-test logic so tapping a button
-#     in the browser calls its callback, just like clicking in pygame does.
+# JSON draw-call renderer for the web frontend.  Every drawing primitive
+# appends a compact dict to self._calls; present() serialises the list to
+# JSON and pushes it to the browser over WebSocket.  The browser replays the
+# draw calls on an HTML5 canvas.
 #
-# The inputSource reference is injected by WebSession so drawButton() can read
-# mouse state without going through pygame.  It is only used during drawing
-# (same pattern as PygameRenderer.drawButton), so the coupling is narrow.
-class WebRenderer(TextRenderer):
+# supportsImageLoading() returns True so the game uses the full sprite/tile
+# rendering path (same as pygame) instead of the text-mode glyph fallback.
+# loadImage() returns the asset path string; the browser fetches the image
+# from the HTTP server at /assets/... automatically on first use.
+class WebRenderer(Renderer):
+    _SCREEN = object()  # sentinel: render target is the main canvas
+
     def __init__(
         self,
         sendCallback,
-        columns=_DEFAULT_COLUMNS,
-        rows=_DEFAULT_ROWS,
+        width=_DEFAULT_WIDTH,
+        height=_DEFAULT_HEIGHT,
         inputSource=None,
     ):
-        super().__init__(columns=columns, rows=rows)
-        self._sendCallback = sendCallback
+        self._send = sendCallback
+        self._w = int(width)
+        self._h = int(height)
         self._inputSource = inputSource
+        self._calls = []
+        self._target = self._SCREEN
+        self._lastPayload = None
+
+    # ── display size ─────────────────────────────────────────────────────────
+
+    def resize(self, width, height):
+        self._w = int(width)
+        self._h = int(height)
+
+    def getDisplayWidth(self):
+        return self._w
+
+    def getDisplayHeight(self):
+        return self._h
+
+    def getDisplaySize(self):
+        return (self._w, self._h)
+
+    def getGameAreaRect(self):
+        side = min(self._w, self._h)
+        x = (self._w - side) // 2
+        y = (self._h - side) // 2
+        return Rect(x, y, side, side)
+
+    # ── lifecycle ──────��─────────────────────────────��───────────────────────
+
+    def supportsImageLoading(self):
+        return True
+
+    def setCaption(self, text):
+        pass
+
+    def captureScreenshot(self):
+        return False
+
+    def present(self):
+        if self._target is not self._SCREEN or not self._calls:
+            return
+        payload = json.dumps(
+            {"type": "frame", "w": self._w, "h": self._h, "calls": self._calls},
+            separators=(",", ":"),
+        )
+        self._calls = []
+        if payload == self._lastPayload:
+            return
+        self._lastPayload = payload
+        self._send(payload)
+
+    # ── clear ─────────────────────────────────────────────────────────────────
+
+    def clearScreen(self, color):
+        self._emit({"op": "clear", "color": _rgb(color)})
+
+    # ── images ───��──────────────────────────────────────────────────────────��
+
+    def loadImage(self, path):
+        """Return the asset path; the browser fetches /assets/... via HTTP."""
+        return path
+
+    def tryLoadImage(self, path):
+        """Minimap requires on-disk PNGs; not supported in web mode."""
+        return None
+
+    def scaleImage(self, image, size):
+        path = image if isinstance(image, str) else image.get("path", "")
+        return {"path": path, "w": int(size[0]), "h": int(size[1])}
+
+    def drawImage(self, image, position):
+        call = {"op": "img"}
+        if isinstance(image, str):
+            call["path"] = image
+        else:
+            call["path"] = image.get("path", "")
+            if "w" in image:
+                call["w"] = image["w"]
+                call["h"] = image["h"]
+        try:
+            call["x"] = int(position[0])
+            call["y"] = int(position[1])
+        except (TypeError, KeyError):
+            call["x"] = int(position.x)
+            call["y"] = int(position.y)
+        self._emit(call)
+
+    def createSurface(self, size):
+        return _OffscreenSurface()
+
+    def saveImage(self, image, path):
+        pass
+
+    # ── drawing ─────��────────────────────────────────���───────────────────────
+
+    def drawRectangle(self, x, y, w, h, color):
+        self._emit(
+            {
+                "op": "rect",
+                "x": int(x),
+                "y": int(y),
+                "w": int(w),
+                "h": int(h),
+                "color": _rgb(color),
+            }
+        )
+
+    def drawText(self, text, x, y, size, color):
+        self._emit(
+            {
+                "op": "text",
+                "text": str(text),
+                "x": int(x),
+                "y": int(y),
+                "size": int(size),
+                "color": _rgb(color),
+                "align": "c",
+            }
+        )
+
+    def drawTextLeftAligned(self, text, x, y, size, color):
+        self._emit(
+            {
+                "op": "text",
+                "text": str(text),
+                "x": int(x),
+                "y": int(y),
+                "size": int(size),
+                "color": _rgb(color),
+                "align": "l",
+            }
+        )
 
     def drawButton(
         self, xpos, ypos, width, height, colorBox, colorText, sizeText, text, function
     ):
-        super().drawButton(
-            xpos, ypos, width, height, colorBox, colorText, sizeText, text, function
+        self._emit(
+            {
+                "op": "button",
+                "x": int(xpos),
+                "y": int(ypos),
+                "w": int(width),
+                "h": int(height),
+                "bc": _rgb(colorBox),
+                "tc": _rgb(colorText),
+                "text": text,
+            }
         )
-        if self._inputSource is None:
-            return
-        mx, my = self._inputSource.getMousePosition()
-        mb = self._inputSource.getMouseButtons()
-        if mb[0] and xpos <= mx < xpos + width and ypos <= my < ypos + height:
-            # Consume the click immediately so the callback isn't called again
-            # on the next frame before the mouse_up message arrives (~80 ms).
-            self._inputSource.consumeLeftClick()
-            function()
+        if self._target is self._SCREEN and self._inputSource is not None:
+            mx, my = self._inputSource.getMousePosition()
+            mb = self._inputSource.getMouseButtons()
+            if mb[0] and xpos <= mx < xpos + width and ypos <= my < ypos + height:
+                self._inputSource.consumeLeftClick()
+                function()
 
-    def present(self):
-        frame = self.grid.toString()
-        if frame == self._lastFrame:
-            return
-        newLines = frame.split("\n")
-        oldLines = self._lastFrame.split("\n") if self._lastFrame is not None else []
-        diff = _buildDiff(newLines, oldLines)
-        self._lastFrame = frame
-        if diff:
-            self._sendCallback(diff)
+    def drawTranslucentOverlay(self, color):
+        c = list(color[:3]) + [int(color[3]) if len(color) > 3 else 128]
+        self._emit({"op": "overlay", "color": c})
+
+    def drawDayNightOverlay(self, gameAreaRect, opacity, lightSources):
+        try:
+            gx, gy, gw, gh = (
+                gameAreaRect.x,
+                gameAreaRect.y,
+                gameAreaRect.width,
+                gameAreaRect.height,
+            )
+        except AttributeError:
+            gx, gy, gw, gh = gameAreaRect
+        self._emit(
+            {
+                "op": "daynight",
+                "opacity": int(opacity),
+                "lights": [[int(x), int(y), int(r)] for x, y, r in lightSources],
+                "rect": [int(gx), int(gy), int(gw), int(gh)],
+            }
+        )
+
+    # ── clip region ───���──────────────────────────────────────────────────────
+
+    def setClipRegion(self, rect):
+        if rect is None:
+            self._emit({"op": "unclip"})
+        else:
+            self._emit(
+                {
+                    "op": "clip",
+                    "x": int(rect.x),
+                    "y": int(rect.y),
+                    "w": int(rect.width),
+                    "h": int(rect.height),
+                }
+            )
+
+    # ── render target (offscreen suppressed for minimap) ─────────────────────
+
+    def getRenderTarget(self):
+        return self._target
+
+    def setRenderTarget(self, target):
+        self._target = target if target is not None else self._SCREEN
+
+    # ── internal ─────────────────────────────────��───────────────────────────
+
+    def _emit(self, call):
+        if self._target is self._SCREEN:
+            self._calls.append(call)
+        # offscreen draw calls are silently discarded (minimap not supported)
+
+
+def _rgb(color):
+    return [int(color[0]), int(color[1]), int(color[2])]

--- a/src/rendering/webRenderer.py
+++ b/src/rendering/webRenderer.py
@@ -8,14 +8,41 @@ _DEFAULT_ROWS = 36
 # @since June 27th, 2026
 #
 # WebSocket implementation of Renderer (web-frontend epic). Inherits all of
-# TextRenderer's drawing logic unchanged; the only override is present(), which
-# sends the ANSI diff to the connected browser via a thread-safe callback
-# instead of writing to stdout. The callback is provided by WebSession so the
-# renderer itself is unaware of asyncio.
+# TextRenderer's drawing logic unchanged; the main overrides are:
+#   - present(): sends the ANSI diff to the browser via a thread-safe callback
+#   - drawButton(): mirrors PygameRenderer's hit-test logic so tapping a button
+#     in the browser calls its callback, just like clicking in pygame does.
+#
+# The inputSource reference is injected by WebSession so drawButton() can read
+# mouse state without going through pygame.  It is only used during drawing
+# (same pattern as PygameRenderer.drawButton), so the coupling is narrow.
 class WebRenderer(TextRenderer):
-    def __init__(self, sendCallback, columns=_DEFAULT_COLUMNS, rows=_DEFAULT_ROWS):
+    def __init__(
+        self,
+        sendCallback,
+        columns=_DEFAULT_COLUMNS,
+        rows=_DEFAULT_ROWS,
+        inputSource=None,
+    ):
         super().__init__(columns=columns, rows=rows)
         self._sendCallback = sendCallback
+        self._inputSource = inputSource
+
+    def drawButton(
+        self, xpos, ypos, width, height, colorBox, colorText, sizeText, text, function
+    ):
+        super().drawButton(
+            xpos, ypos, width, height, colorBox, colorText, sizeText, text, function
+        )
+        if self._inputSource is None:
+            return
+        mx, my = self._inputSource.getMousePosition()
+        mb = self._inputSource.getMouseButtons()
+        if mb[0] and xpos <= mx < xpos + width and ypos <= my < ypos + height:
+            # Consume the click immediately so the callback isn't called again
+            # on the next frame before the mouse_up message arrives (~80 ms).
+            self._inputSource.consumeLeftClick()
+            function()
 
     def present(self):
         frame = self.grid.toString()

--- a/src/rendering/webRenderer.py
+++ b/src/rendering/webRenderer.py
@@ -1,0 +1,29 @@
+from rendering.textRenderer import TextRenderer, _buildDiff
+
+_DEFAULT_COLUMNS = 120
+_DEFAULT_ROWS = 36
+
+
+# @author Daniel McCoy Stephenson
+# @since June 27th, 2026
+#
+# WebSocket implementation of Renderer (web-frontend epic). Inherits all of
+# TextRenderer's drawing logic unchanged; the only override is present(), which
+# sends the ANSI diff to the connected browser via a thread-safe callback
+# instead of writing to stdout. The callback is provided by WebSession so the
+# renderer itself is unaware of asyncio.
+class WebRenderer(TextRenderer):
+    def __init__(self, sendCallback, columns=_DEFAULT_COLUMNS, rows=_DEFAULT_ROWS):
+        super().__init__(columns=columns, rows=rows)
+        self._sendCallback = sendCallback
+
+    def present(self):
+        frame = self.grid.toString()
+        if frame == self._lastFrame:
+            return
+        newLines = frame.split("\n")
+        oldLines = self._lastFrame.split("\n") if self._lastFrame is not None else []
+        diff = _buildDiff(newLines, oldLines)
+        self._lastFrame = frame
+        if diff:
+            self._sendCallback(diff)

--- a/src/roam.py
+++ b/src/roam.py
@@ -10,7 +10,7 @@ import sys
 # is ever initialised, preventing log lines from corrupting the TUI display.
 # ---------------------------------------------------------------------------
 def _earlyDetectTextMode():
-    if "--text" in sys.argv:
+    if "--text" in sys.argv or "--web" in sys.argv:
         return True
     try:
         import pygame as _pg
@@ -65,15 +65,18 @@ _logger = getLogger(__name__)
 # @author Daniel McCoy Stephenson
 # @since August 8th, 2022
 class Roam:
-    def __init__(self, config: Config, textMode=False):
+    def __init__(self, config: Config, textMode=False, frontend=None):
         self.config = config
         self.textMode = textMode
         # The frontend owns the display + input lifecycle; the game depends only
         # on the Renderer/InputSource/Clock it provides (epic #433). Selecting a
         # different frontend swaps the whole backend with no game-logic change.
-        self.frontend = (
-            createTextFrontend(config) if textMode else createFrontend(config)
-        )
+        if frontend is not None:
+            self.frontend = frontend
+        else:
+            self.frontend = (
+                createTextFrontend(config) if textMode else createFrontend(config)
+            )
         self._initializeDependencies()
         _logger.info("game initialized", savePath=config.pathToSaveDirectory)
 
@@ -256,6 +259,24 @@ def main(argv):
         return runSelfTest()
 
     config = Config()
+
+    if "--web" in argv:
+        from rendering.webFrontend import WebFrontend
+
+        def _sessionGameLoop(session):
+            roam = Roam(config, frontend=session)
+            try:
+                while True:
+                    result = roam.run()
+                    if result != "restart":
+                        break
+                    roam.restart()
+            except KeyboardInterrupt:
+                pass
+
+        WebFrontend().serve(_sessionGameLoop)
+        return 0
+
     roam = Roam(config, textMode=_shouldUseTextMode(argv))
     try:
         while True:

--- a/web/index.html
+++ b/web/index.html
@@ -2,57 +2,89 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <!-- user-scalable=yes lets players pinch-zoom if they want; the layout itself
+       already fits the viewport so there is no forced double-tap zoom surprise. -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
   <title>Roam</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.css" />
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
-    body {
+    /* Fill the viewport exactly; 100dvh accounts for mobile browser chrome. */
+    html, body {
+      height: 100%;
+      height: 100dvh;
+      overflow: hidden;
       background: #111;
       color: #ccc;
       font-family: "Courier New", Courier, monospace;
+    }
+
+    body {
       display: flex;
       flex-direction: column;
+      align-items: stretch;
+      padding: 4px;
+      gap: 4px;
+    }
+
+    /* ── header ── */
+    #header {
+      display: flex;
       align-items: center;
-      padding: 8px 4px 12px;
-      min-height: 100dvh;
-      gap: 6px;
-      overflow-x: hidden;
+      justify-content: space-between;
+      flex-shrink: 0;
+      gap: 8px;
+      padding: 0 2px;
+    }
+    h1    { font-size: 1.1rem; letter-spacing: 0.1em; color: #e8c97a; white-space: nowrap; }
+    #status { font-size: 0.75rem; color: #888; text-align: right; flex: 1; }
+    #reconnect {
+      display: none;
+      padding: 3px 10px;
+      background: #2a2a2a;
+      color: #e8c97a;
+      border: 1px solid #555;
+      border-radius: 3px;
+      cursor: pointer;
+      font-family: inherit;
+      font-size: 0.75rem;
+      flex-shrink: 0;
+    }
+    #reconnect:active { background: #3a3a3a; }
+
+    /* ── terminal ─────────────────────────────────────────────────────────
+       flex: 1 + min-height: 0 lets the terminal shrink to share space with
+       the controls row.  FitAddon measures the final pixel dimensions and
+       adjusts cols/rows so the canvas never overflows this container.
+    ── */
+    #terminal-outer {
+      flex: 1;
+      min-height: 0;
+      width: 100%;
+      overflow: hidden;
+      border: 1px solid #222;
+      border-radius: 3px;
     }
 
-    h1 { font-size: 1.3rem; letter-spacing: 0.12em; color: #e8c97a; }
-
-    #status {
-      font-size: 0.8rem;
-      color: #888;
-      min-height: 1.1em;
-      text-align: center;
+    /* xterm.js needs the host element to fill the container. */
+    #terminal {
+      width: 100%;
+      height: 100%;
     }
 
-    /* ── terminal ── */
-    #terminal-wrap {
-      border: 1px solid #2a2a2a;
-      border-radius: 4px;
-      overflow: auto;           /* allow pinch-zoom to reveal clipped content */
-      touch-action: pinch-zoom; /* browser handles pinch; we handle tap via buttons */
-      max-width: 100%;
-    }
-
-    /* ── on-screen controls (shown only on touch devices via JS) ── */
+    /* ── on-screen controls (shown on touch devices) ── */
     #controls {
       display: none;
       flex-direction: column;
       align-items: center;
       gap: 4px;
-      width: 100%;
-      max-width: 400px;
-      margin-top: 4px;
+      flex-shrink: 0;
     }
 
     .btn-row {
       display: flex;
-      gap: 6px;
+      gap: 5px;
       justify-content: center;
     }
 
@@ -64,9 +96,8 @@
       font-family: inherit;
       font-size: 1.1rem;
       cursor: pointer;
-      /* comfortable tap target */
-      min-width: 52px;
-      min-height: 52px;
+      min-width: 48px;
+      min-height: 48px;
       display: flex;
       align-items: center;
       justify-content: center;
@@ -75,44 +106,24 @@
       touch-action: manipulation;
     }
     .ctrl-btn:active { background: #333; border-color: #e8c97a; color: #e8c97a; }
-
-    .ctrl-btn.wide  { min-width: 110px; font-size: 0.85rem; }
-    .ctrl-btn.small { min-width: 44px; min-height: 44px; font-size: 0.8rem; }
-
-    /* spacer cell in the D-pad grid */
-    .ctrl-spacer { min-width: 52px; min-height: 52px; }
-
-    /* ── action button strip ── */
-    #action-row { flex-wrap: wrap; justify-content: center; gap: 6px; }
-
-    /* ── status / reconnect ── */
-    #reconnect {
-      display: none;
-      padding: 6px 18px;
-      background: #2a2a2a;
-      color: #e8c97a;
-      border: 1px solid #555;
-      border-radius: 3px;
-      cursor: pointer;
-      font-family: inherit;
-      font-size: 0.85rem;
-    }
-    #reconnect:hover, #reconnect:active { background: #3a3a3a; }
-
-    footer { font-size: 0.7rem; color: #444; text-align: center; }
+    .ctrl-btn.wide  { min-width: 96px; font-size: 0.8rem; }
+    .ctrl-btn.small { min-width: 42px; min-height: 42px; font-size: 0.8rem; }
+    .ctrl-spacer    { min-width: 48px; min-height: 48px; }
   </style>
 </head>
 <body>
-  <h1>Roam</h1>
-  <div id="status">Connecting&hellip;</div>
+  <div id="header">
+    <h1>Roam</h1>
+    <div id="status">Connecting&hellip;</div>
+    <button id="reconnect" onclick="connect()">Reconnect</button>
+  </div>
 
-  <div id="terminal-wrap">
+  <div id="terminal-outer">
     <div id="terminal"></div>
   </div>
 
-  <!-- On-screen controls — shown automatically on touch devices -->
+  <!-- On-screen controls — revealed on touch devices via JS -->
   <div id="controls">
-    <!-- D-pad -->
     <div class="btn-row">
       <div class="ctrl-spacer"></div>
       <button class="ctrl-btn" data-key="up"    title="Up">▲</button>
@@ -120,7 +131,7 @@
     </div>
     <div class="btn-row">
       <button class="ctrl-btn" data-key="left"  title="Left">◀</button>
-      <button class="ctrl-btn" data-key="enter" title="Interact / Confirm">✔</button>
+      <button class="ctrl-btn" data-key="enter" title="Confirm / Interact">✔</button>
       <button class="ctrl-btn" data-key="right" title="Right">▶</button>
     </div>
     <div class="btn-row">
@@ -128,9 +139,7 @@
       <button class="ctrl-btn" data-key="down"  title="Down">▼</button>
       <div class="ctrl-spacer"></div>
     </div>
-
-    <!-- Action buttons -->
-    <div class="btn-row" id="action-row">
+    <div class="btn-row">
       <button class="ctrl-btn small" data-key="g"      title="Gather (G)">G</button>
       <button class="ctrl-btn small" data-key="f"      title="Place / Use (F)">F</button>
       <button class="ctrl-btn small" data-key="i"      title="Inventory (I)">I</button>
@@ -140,20 +149,11 @@
     </div>
   </div>
 
-  <button id="reconnect" onclick="connect()">Reconnect</button>
-  <footer>Keyboard or on-screen controls &bull; pinch to zoom &bull; F1 for help</footer>
-
   <script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/lib/xterm-addon-fit.js"></script>
   <script>
     const WS_PORT = 8765;
-    const COLS    = 120;
-    const ROWS    = 36;
 
-    const statusEl    = document.getElementById("status");
-    const reconnectBtn = document.getElementById("reconnect");
-    const controlsEl  = document.getElementById("controls");
-
-    // Map button data-key values to the bytes xterm.js / the server expects.
     const KEY_SEQUENCES = {
       up:     "\x1b[A",
       down:   "\x1b[B",
@@ -162,50 +162,70 @@
       enter:  "\r",
       escape: "\x1b",
       f1:     "\x1bOP",
-      g:      "g",
-      f:      "f",
-      i:      "i",
-      c:      "c",
+      g: "g", f: "f", i: "i", c: "c",
     };
+
+    const statusEl     = document.getElementById("status");
+    const reconnectBtn = document.getElementById("reconnect");
+    const controlsEl   = document.getElementById("controls");
 
     // ── terminal ──────────────────────────────────────────────────────────
     const term = new Terminal({
-      cols: COLS,
-      rows: ROWS,
       theme: {
         background:   "#111111",
         foreground:   "#d4d4d4",
         cursor:       "#d4d4d4",
         black:        "#111111",
         brightBlack:  "#555555",
-        red:          "#cc3333",
-        brightRed:    "#ff5555",
-        green:        "#33aa33",
-        brightGreen:  "#55cc55",
-        yellow:       "#aa8833",
-        brightYellow: "#ffcc44",
-        cyan:         "#33aacc",
-        brightCyan:   "#55ccff",
-        white:        "#cccccc",
-        brightWhite:  "#ffffff",
+        red:          "#cc3333", brightRed:    "#ff5555",
+        green:        "#33aa33", brightGreen:  "#55cc55",
+        yellow:       "#aa8833", brightYellow: "#ffcc44",
+        cyan:         "#33aacc", brightCyan:   "#55ccff",
+        white:        "#cccccc", brightWhite:  "#ffffff",
       },
-      fontFamily:  "'Courier New', Courier, monospace",
-      fontSize:    14,
-      cursorBlink: false,
-      disableStdin: false,
-      convertEol:  false,
+      fontFamily:   "'Courier New', Courier, monospace",
+      fontSize:     14,
+      cursorBlink:  false,
+      convertEol:   false,
+      scrollback:   0,  // no scroll buffer — game redraws the whole frame
     });
+
+    const fitAddon = new FitAddon.FitAddon();
+    term.loadAddon(fitAddon);
     term.open(document.getElementById("terminal"));
 
-    // ── touch detection — show on-screen controls on touch devices ────────
+    // ── touch detection — show controls, then refit to account for them ───
     function isTouchDevice() {
       return "ontouchstart" in window || navigator.maxTouchPoints > 0;
     }
+
     if (isTouchDevice()) {
       controlsEl.style.display = "flex";
     } else {
       term.focus();
     }
+
+    // ── FitAddon — resize terminal to fill its container ──────────────────
+    // Run after the controls (if any) are visible so the container height is
+    // correct.  requestAnimationFrame lets the browser do one layout pass first.
+    function fitAndNotify() {
+      requestAnimationFrame(() => {
+        try { fitAddon.fit(); } catch (_) {}
+        sendResize();
+      });
+    }
+
+    // Send the xterm resize report (CSI 8 ; rows ; cols t) so the server's
+    // WebRenderer re-creates its grid at the actual terminal dimensions.
+    function sendResize() {
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(`\x1b[8;${term.rows};${term.cols}t`);
+      }
+    }
+
+    window.addEventListener("resize", fitAndNotify);
+    // Initial fit — called before connect() so size is known at WS open.
+    fitAndNotify();
 
     // ── WebSocket ─────────────────────────────────────────────────────────
     let ws = null;
@@ -229,6 +249,8 @@
       ws.onopen = () => {
         setStatus("Connected");
         term.reset();
+        // Tell the server the actual terminal size immediately.
+        sendResize();
         if (!isTouchDevice()) term.focus();
       };
 
@@ -240,7 +262,7 @@
       };
 
       ws.onerror = () => {
-        setStatus(`Connection error — server on port ${WS_PORT}?`, true);
+        setStatus(`Error — server on port ${WS_PORT}?`, true);
         reconnectBtn.style.display = "inline-block";
       };
 
@@ -248,24 +270,11 @@
     }
 
     // ── on-screen button wiring ───────────────────────────────────────────
-    // Use touchstart so response is instant (no 300 ms tap delay).
-    // preventDefault stops the browser also firing a click and doubling input.
     document.querySelectorAll(".ctrl-btn").forEach((btn) => {
-      const key = btn.dataset.key;
-      const seq = KEY_SEQUENCES[key];
+      const seq = KEY_SEQUENCES[btn.dataset.key];
       if (!seq) return;
-
-      // touchstart for fast response on mobile
-      btn.addEventListener("touchstart", (e) => {
-        e.preventDefault();
-        send(seq);
-      }, { passive: false });
-
-      // mousedown so desktop users can also click the buttons
-      btn.addEventListener("mousedown", (e) => {
-        e.preventDefault();
-        send(seq);
-      });
+      btn.addEventListener("touchstart", (e) => { e.preventDefault(); send(seq); }, { passive: false });
+      btn.addEventListener("mousedown",  (e) => { e.preventDefault(); send(seq); });
     });
 
     connect();

--- a/web/index.html
+++ b/web/index.html
@@ -33,6 +33,7 @@
     }
     #bar-status { flex: 1; color: #666; }
     #bar-reconnect {
+      display: none;   /* hidden until disconnected */
       background: #1e1e1e;
       border: 1px solid #444;
       color: #aaa;
@@ -48,6 +49,7 @@
       flex: 1;
       min-height: 0;
       position: relative;
+      cursor: crosshair;
     }
     #game-canvas {
       width: 100%;
@@ -148,9 +150,11 @@
 
   const WS_PORT = 8765;
 
-  const canvas   = document.getElementById("game-canvas");
-  const ctx      = canvas.getContext("2d");
-  const statusEl = document.getElementById("bar-status");
+  const canvas      = document.getElementById("game-canvas");
+  const ctx         = canvas.getContext("2d");
+  const statusEl    = document.getElementById("bar-status");
+  const reconnectEl = document.getElementById("bar-reconnect");
+  const canvasWrap  = document.getElementById("canvas-wrap");
 
   // ── image cache ────────────────────────────────────────────────────────────
   const imgCache = {};
@@ -183,10 +187,25 @@
     sendJSON({ type: "resize", w, h });
   }
 
-  window.addEventListener("resize", () => {
-    // After resize, the DPR scale set in resizeCanvas is reset; redo it.
-    resizeCanvas();
-  });
+  window.addEventListener("resize", resizeCanvas);
+
+  // ── loading overlay ────────────────────────────────────────────────────────
+  let _firstFrame = false;
+
+  function drawLoading() {
+    const dpr  = window.devicePixelRatio || 1;
+    const cssW = canvas.clientWidth;
+    const cssH = canvas.clientHeight;
+    ctx.save();
+    ctx.fillStyle = "#0a0a0a";
+    ctx.fillRect(0, 0, cssW, cssH);
+    ctx.fillStyle = "#444";
+    ctx.font = `${Math.round(cssH * 0.025 + 10)}px system-ui`;
+    ctx.textAlign    = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText("Loading…", cssW / 2, cssH / 2);
+    ctx.restore();
+  }
 
   // ── frame rendering ────────────────────────────────────────────────────────
   function renderFrame(raw) {
@@ -194,10 +213,10 @@
     try { frame = JSON.parse(raw); } catch { return; }
     if (frame.type !== "frame") return;
 
+    _firstFrame = true;
     gameW = frame.w;
     gameH = frame.h;
 
-    const dpr   = window.devicePixelRatio || 1;
     const cssW  = canvas.clientWidth;
     const cssH  = canvas.clientHeight;
     const scaleX = cssW / gameW;
@@ -223,7 +242,15 @@
 
         case "img": {
           const im = cachedImg(c.path);
-          ctx.drawImage(im, c.x, c.y, c.w || 32, c.h || 32);
+          const w  = c.w || 32;
+          const h  = c.h || 32;
+          if (im.complete && im.naturalWidth > 0) {
+            ctx.drawImage(im, c.x, c.y, w, h);
+          } else {
+            // Placeholder tile while browser fetches the image
+            ctx.fillStyle = "#222";
+            ctx.fillRect(c.x, c.y, w, h);
+          }
           break;
         }
 
@@ -237,14 +264,11 @@
         }
 
         case "button": {
-          // Box fill
           ctx.fillStyle = rgb(c.bc || [40, 40, 40]);
           ctx.fillRect(c.x, c.y, c.w, c.h);
-          // Border
-          ctx.strokeStyle = "#666";
-          ctx.lineWidth   = 2;
-          ctx.strokeRect(c.x + 1, c.y + 1, c.w - 2, c.h - 2);
-          // Label
+          ctx.strokeStyle = "rgba(255,255,255,0.15)";
+          ctx.lineWidth   = 1;
+          ctx.strokeRect(c.x + 0.5, c.y + 0.5, c.w - 1, c.h - 1);
           const fs = Math.min(Math.floor(c.h * 0.42), 28);
           ctx.font         = `bold ${fs}px sans-serif`;
           ctx.fillStyle    = rgb(c.tc || [255, 255, 255]);
@@ -329,12 +353,25 @@
 
   function connect() {
     if (ws && ws.readyState !== WebSocket.CLOSED) ws.close();
+    _firstFrame = false;
     setStatus("Connecting…");
+    reconnectEl.style.display = "none";
     ws = new WebSocket(`ws://${location.hostname}:${WS_PORT}`);
-    ws.onopen    = () => { setStatus("Connected"); sendResize(); };
+    ws.onopen    = () => {
+      setStatus("Connected");
+      reconnectEl.style.display = "none";
+      sendResize();
+      drawLoading();
+    };
     ws.onmessage = (e) => renderFrame(e.data);
-    ws.onclose   = () => setStatus("Disconnected — click Reconnect to retry", true);
-    ws.onerror   = () => setStatus(`Cannot reach ${location.hostname}:${WS_PORT}`, true);
+    ws.onclose   = () => {
+      setStatus("Disconnected — tap Reconnect to retry", true);
+      reconnectEl.style.display = "";
+    };
+    ws.onerror   = () => {
+      setStatus(`Cannot reach ${location.hostname}:${WS_PORT}`, true);
+      reconnectEl.style.display = "";
+    };
   }
 
   // ── touch detection ────────────────────────────────────────────────────────
@@ -391,7 +428,6 @@
     const key  = btn.dataset.key;
     const seq  = KEY_SEQS[key];
     if (!seq) return;
-    const rep = REPEAT_KEYS.has(key);
 
     btn.addEventListener("touchstart",  (e) => { e.preventDefault(); btn.classList.add("pressed");    startKey(key, seq); }, { passive: false });
     btn.addEventListener("touchend",    (e) => { e.preventDefault(); btn.classList.remove("pressed"); stopKey(); },          { passive: false });
@@ -401,9 +437,7 @@
     btn.addEventListener("mouseleave",  ()  => { btn.classList.remove("pressed"); stopKey(); });
   });
 
-  // ── tap-to-interact ────────────────────────────────────────────────────────
-  // Convert a browser-pixel position on the canvas to the server's game-pixel
-  // coordinate space.  gameW / gameH are updated each frame from the server.
+  // ── mouse coordinate conversion ────────────────────────────────────────────
   function canvasToGame(clientX, clientY) {
     const rect = canvas.getBoundingClientRect();
     const bx = clientX - rect.left;
@@ -419,39 +453,88 @@
     sendJSON({ type, x: gp.x, y: gp.y, button });
   }
 
-  const canvasWrap = document.getElementById("canvas-wrap");
+  function sendMouseMove(clientX, clientY) {
+    const gp = canvasToGame(clientX, clientY);
+    sendJSON({ type: "mouse_move", x: gp.x, y: gp.y });
+  }
 
-  // Touch: short tap = left-click (gather/select); long-press = right-click (place)
-  let _tapTimer = null, _tapStart = null, _tapLong = false;
+  // ── tap-to-interact ────────────────────────────────────────────────────────
+  // Gesture states:
+  //   short tap  (<450ms, <5px move) → left click (gather / select button)
+  //   long press (≥450ms, <5px move) → right click (place)
+  //   drag       (≥5px move)         → left-click-drag (HUD repositioning)
+  let _tapTimer  = null;
+  let _tapStart  = null;
+  let _tapLong   = false;
+  let _dragActive = false;
+  let _lastMoveSent = 0;
 
   canvasWrap.addEventListener("touchstart", (e) => {
     if (e.touches.length !== 1) return;
     e.preventDefault();
-    const t    = e.touches[0];
+    const t   = e.touches[0];
     _tapStart  = { x: t.clientX, y: t.clientY };
     _tapLong   = false;
+    _dragActive = false;
     _tapTimer  = setTimeout(() => {
       _tapLong = true;
       sendMouseEvent("mouse_down", _tapStart.x, _tapStart.y, 3);
     }, 450);
   }, { passive: false });
 
+  canvasWrap.addEventListener("touchmove", (e) => {
+    if (e.touches.length !== 1) return;
+    e.preventDefault();
+    const t = e.touches[0];
+
+    if (!_dragActive && _tapStart) {
+      const dx = t.clientX - _tapStart.x;
+      const dy = t.clientY - _tapStart.y;
+      if (Math.hypot(dx, dy) > 5) {
+        clearTimeout(_tapTimer);
+        _tapLong    = false;
+        _dragActive = true;
+        // Send mouse_down at original touch position to start the drag
+        sendMouseEvent("mouse_down", _tapStart.x, _tapStart.y, 1);
+      }
+    }
+
+    if (_dragActive) {
+      const now = Date.now();
+      if (now - _lastMoveSent >= 40) {
+        _lastMoveSent = now;
+        sendMouseMove(t.clientX, t.clientY);
+      }
+    }
+  }, { passive: false });
+
   canvasWrap.addEventListener("touchend", (e) => {
     e.preventDefault();
     clearTimeout(_tapTimer);
+    const t = e.changedTouches[0];
     if (_tapLong) {
-      const t = e.changedTouches[0];
       sendMouseEvent("mouse_up", t.clientX, t.clientY, 3);
+    } else if (_dragActive) {
+      sendMouseEvent("mouse_up", t.clientX, t.clientY, 1);
     } else if (_tapStart) {
+      // Short tap: fire click at original touch-down position
       sendMouseEvent("mouse_down", _tapStart.x, _tapStart.y, 1);
       setTimeout(() => sendMouseEvent("mouse_up", _tapStart.x, _tapStart.y, 1), 60);
     }
-    _tapStart = null;
+    _tapStart   = null;
+    _tapLong    = false;
+    _dragActive = false;
   }, { passive: false });
 
   canvasWrap.addEventListener("touchcancel", (e) => {
     clearTimeout(_tapTimer);
-    _tapStart = null;
+    if (_dragActive) {
+      const t = e.changedTouches[0];
+      sendMouseEvent("mouse_up", t.clientX, t.clientY, 1);
+    }
+    _tapStart   = null;
+    _tapLong    = false;
+    _dragActive = false;
   }, { passive: false });
 
   // Desktop mouse
@@ -462,6 +545,12 @@
   canvasWrap.addEventListener("mouseup", (e) => {
     const btn = e.button === 2 ? 3 : 1;
     sendMouseEvent("mouse_up", e.clientX, e.clientY, btn);
+  });
+  canvasWrap.addEventListener("mousemove", (e) => {
+    const now = Date.now();
+    if (now - _lastMoveSent < 40) return;
+    _lastMoveSent = now;
+    sendMouseMove(e.clientX, e.clientY);
   });
   canvasWrap.addEventListener("contextmenu", (e) => e.preventDefault());
 

--- a/web/index.html
+++ b/web/index.html
@@ -277,6 +277,78 @@
       btn.addEventListener("mousedown",  (e) => { e.preventDefault(); send(seq); });
     });
 
+    // ── tap-to-interact ───────────────────────────────────────────────────
+    // Convert a browser-pixel position inside the xterm canvas to the game's
+    // pixel coordinate system (server uses cellWidth=8, cellHeight=16).
+    // The mapping: browser tap → character cell (col,row) → game pixels.
+    function terminalGamePixels(clientX, clientY) {
+      const screen = document.querySelector(".xterm-screen");
+      if (!screen) return null;
+      const rect  = screen.getBoundingClientRect();
+      const bx    = clientX - rect.left;
+      const by    = clientY - rect.top;
+      const cellW = rect.width  / term.cols;
+      const cellH = rect.height / term.rows;
+      const col   = Math.floor(bx / cellW);
+      const row   = Math.floor(by / cellH);
+      return { x: col * 8, y: row * 16 };   // 8/16 = server's cellWidth/cellHeight
+    }
+
+    function sendMouse(type, clientX, clientY, button) {
+      const gp = terminalGamePixels(clientX, clientY);
+      if (gp) send(JSON.stringify({ type, x: gp.x, y: gp.y, button }));
+    }
+
+    const termOuter = document.getElementById("terminal-outer");
+
+    // Touch: tap or long-press on the game canvas
+    let _tapTimer    = null;
+    let _tapStart    = null;
+    let _longPressed = false;
+
+    termOuter.addEventListener("touchstart", (e) => {
+      // Ignore multi-touch — we only handle single-finger taps
+      if (e.touches.length !== 1) return;
+      e.preventDefault();
+      const t = e.touches[0];
+      _tapStart    = { x: t.clientX, y: t.clientY };
+      _longPressed = false;
+
+      // Long-press (≥450 ms) → right-click → place/interact
+      _tapTimer = setTimeout(() => {
+        _longPressed = true;
+        sendMouse("mouse_down", _tapStart.x, _tapStart.y, 3);  // button 3 = right
+      }, 450);
+    }, { passive: false });
+
+    termOuter.addEventListener("touchend", (e) => {
+      e.preventDefault();
+      clearTimeout(_tapTimer);
+      if (_longPressed) {
+        const t = e.changedTouches[0];
+        sendMouse("mouse_up", t.clientX, t.clientY, 3);
+      } else if (_tapStart) {
+        // Short tap → left-click → gather
+        sendMouse("mouse_down", _tapStart.x, _tapStart.y, 1);
+        // Release immediately so setGathering is cleared on the next frame
+        setTimeout(() => sendMouse("mouse_up", _tapStart.x, _tapStart.y, 1), 80);
+      }
+      _tapStart = null;
+    }, { passive: false });
+
+    // Desktop mouse clicks on the terminal (same code path, different trigger)
+    termOuter.addEventListener("mousedown", (e) => {
+      // button 0=left, 2=right in MouseEvent; map to SDL 1=left, 3=right
+      const btn = e.button === 2 ? 3 : 1;
+      sendMouse("mouse_down", e.clientX, e.clientY, btn);
+    });
+    termOuter.addEventListener("mouseup", (e) => {
+      const btn = e.button === 2 ? 3 : 1;
+      sendMouse("mouse_up", e.clientX, e.clientY, btn);
+    });
+    // Prevent context-menu on right-click so the right-click reaches the game
+    termOuter.addEventListener("contextmenu", (e) => e.preventDefault());
+
     connect();
   </script>
 </body>

--- a/web/index.html
+++ b/web/index.html
@@ -1,383 +1,477 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <!-- user-scalable=yes lets players pinch-zoom if they want; the layout itself
-       already fits the viewport so there is no forced double-tap zoom surprise. -->
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
   <title>Roam</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.css" />
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
-    /* Fill the viewport exactly; 100dvh accounts for mobile browser chrome. */
-    html, body {
-      height: 100%;
+    body {
+      background: #000;
+      color: #ccc;
+      font-family: system-ui, sans-serif;
+      display: flex;
+      flex-direction: column;
       height: 100dvh;
       overflow: hidden;
-      background: #111;
-      color: #ccc;
-      font-family: "Courier New", Courier, monospace;
-    }
-
-    body {
-      display: flex;
-      flex-direction: column;
-      align-items: stretch;
-      padding: 4px;
-      gap: 4px;
-    }
-
-    /* ── header ── */
-    #header {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      flex-shrink: 0;
-      gap: 8px;
-      padding: 0 2px;
-    }
-    h1    { font-size: 1.1rem; letter-spacing: 0.1em; color: #e8c97a; white-space: nowrap; }
-    #status { font-size: 0.75rem; color: #888; text-align: right; flex: 1; }
-    #reconnect {
-      display: none;
-      padding: 3px 10px;
-      background: #2a2a2a;
-      color: #e8c97a;
-      border: 1px solid #555;
-      border-radius: 3px;
-      cursor: pointer;
-      font-family: inherit;
-      font-size: 0.75rem;
-      flex-shrink: 0;
-    }
-    #reconnect:active { background: #3a3a3a; }
-
-    /* ── terminal ─────────────────────────────────────────────────────────
-       flex: 1 + min-height: 0 lets the terminal shrink to share space with
-       the controls row.  FitAddon measures the final pixel dimensions and
-       adjusts cols/rows so the canvas never overflows this container.
-    ── */
-    #terminal-outer {
-      flex: 1;
-      min-height: 0;
-      width: 100%;
-      overflow: hidden;
-      border: 1px solid #222;
-      border-radius: 3px;
-    }
-
-    /* xterm.js needs the host element to fill the container. */
-    #terminal {
-      width: 100%;
-      height: 100%;
-    }
-
-    /* ── on-screen controls (shown on touch devices) ── */
-    #controls {
-      display: none;
-      flex-direction: column;
-      align-items: center;
-      gap: 4px;
-      flex-shrink: 0;
-    }
-
-    .btn-row {
-      display: flex;
-      gap: 5px;
-      justify-content: center;
-    }
-
-    .ctrl-btn {
-      background: #1e1e1e;
-      color: #ddd;
-      border: 1px solid #444;
-      border-radius: 6px;
-      font-family: inherit;
-      font-size: 1.1rem;
-      cursor: pointer;
-      min-width: 48px;
-      min-height: 48px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
       user-select: none;
       -webkit-user-select: none;
-      touch-action: manipulation;
+      touch-action: none;
     }
-    .ctrl-btn:active { background: #333; border-color: #e8c97a; color: #e8c97a; }
-    .ctrl-btn.wide  { min-width: 96px; font-size: 0.8rem; }
-    .ctrl-btn.small { min-width: 42px; min-height: 42px; font-size: 0.8rem; }
-    .ctrl-spacer    { min-width: 48px; min-height: 48px; }
+
+    /* ── top status bar ──────────────────────────────────────────────────── */
+    #bar {
+      flex-shrink: 0;
+      background: #111;
+      border-bottom: 1px solid #222;
+      padding: 4px 10px;
+      font-size: 12px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+    #bar-status { flex: 1; color: #666; }
+    #bar-reconnect {
+      background: #1e1e1e;
+      border: 1px solid #444;
+      color: #aaa;
+      padding: 2px 10px;
+      cursor: pointer;
+      font-size: 11px;
+      border-radius: 3px;
+    }
+    #bar-reconnect:hover { background: #2a2a2a; }
+
+    /* ── game canvas ─────────────────────────────────────────────────────── */
+    #canvas-wrap {
+      flex: 1;
+      min-height: 0;
+      position: relative;
+    }
+    #game-canvas {
+      width: 100%;
+      height: 100%;
+      display: block;
+      image-rendering: pixelated;
+      image-rendering: crisp-edges;
+    }
+
+    /* ── mobile controls ─────────────────────────────────────────────────── */
+    #controls {
+      display: none;
+      flex-shrink: 0;
+      background: #0e0e0e;
+      border-top: 1px solid #222;
+      padding: 8px 12px;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+    }
+
+    /* D-pad: 3×3 grid with corners empty */
+    .dpad {
+      display: grid;
+      grid-template-columns: repeat(3, 48px);
+      grid-template-rows: repeat(3, 48px);
+      gap: 4px;
+    }
+
+    /* Action buttons: 3×2 grid */
+    .actions {
+      display: grid;
+      grid-template-columns: repeat(3, 48px);
+      grid-template-rows: repeat(2, 48px);
+      gap: 4px;
+    }
+
+    .btn {
+      background: #1c1c1c;
+      border: 1px solid #333;
+      border-radius: 8px;
+      color: #ccc;
+      font-size: 20px;
+      line-height: 1;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      -webkit-tap-highlight-color: transparent;
+      touch-action: none;
+      transition: background 0.06s;
+    }
+    .btn:active, .btn.pressed { background: #3a3a3a; }
+    .btn.confirm { background: #0f2a0f; color: #4e4; border-color: #2a5a2a; }
+    .btn.back    { background: #2a0f0f; color: #e44; border-color: #5a2a2a; }
+    .btn.label   { font-size: 14px; font-weight: 600; letter-spacing: 0.03em; }
+    .dpad-spacer { }
   </style>
 </head>
 <body>
-  <div id="header">
-    <h1>Roam</h1>
-    <div id="status">Connecting&hellip;</div>
-    <button id="reconnect" onclick="connect()">Reconnect</button>
+
+<!-- status bar -->
+<div id="bar">
+  <span id="bar-status">Connecting…</span>
+  <button id="bar-reconnect" onclick="connect()">Reconnect</button>
+</div>
+
+<!-- game canvas -->
+<div id="canvas-wrap">
+  <canvas id="game-canvas"></canvas>
+</div>
+
+<!-- mobile on-screen controls (touch devices only) -->
+<div id="controls">
+  <div class="dpad">
+    <div class="dpad-spacer"></div>
+    <button class="btn" data-key="up">▲</button>
+    <div class="dpad-spacer"></div>
+    <button class="btn" data-key="left">◀</button>
+    <button class="btn confirm" data-key="enter">✔</button>
+    <button class="btn" data-key="right">▶</button>
+    <div class="dpad-spacer"></div>
+    <button class="btn" data-key="down">▼</button>
+    <div class="dpad-spacer"></div>
   </div>
-
-  <div id="terminal-outer">
-    <div id="terminal"></div>
+  <div class="actions">
+    <button class="btn label" data-key="g">G</button>
+    <button class="btn label" data-key="f">F</button>
+    <button class="btn label" data-key="i">I</button>
+    <button class="btn label" data-key="c">C</button>
+    <button class="btn back" data-key="escape">✕</button>
+    <button class="btn label" data-key="f1">?</button>
   </div>
+</div>
 
-  <!-- On-screen controls — revealed on touch devices via JS -->
-  <div id="controls">
-    <div class="btn-row">
-      <div class="ctrl-spacer"></div>
-      <button class="ctrl-btn" data-key="up"    title="Up">▲</button>
-      <div class="ctrl-spacer"></div>
-    </div>
-    <div class="btn-row">
-      <button class="ctrl-btn" data-key="left"  title="Left">◀</button>
-      <button class="ctrl-btn" data-key="enter" title="Confirm / Interact">✔</button>
-      <button class="ctrl-btn" data-key="right" title="Right">▶</button>
-    </div>
-    <div class="btn-row">
-      <div class="ctrl-spacer"></div>
-      <button class="ctrl-btn" data-key="down"  title="Down">▼</button>
-      <div class="ctrl-spacer"></div>
-    </div>
-    <div class="btn-row">
-      <button class="ctrl-btn small" data-key="g"      title="Gather (G)">G</button>
-      <button class="ctrl-btn small" data-key="f"      title="Place / Use (F)">F</button>
-      <button class="ctrl-btn small" data-key="i"      title="Inventory (I)">I</button>
-      <button class="ctrl-btn small" data-key="c"      title="Crafting (C)">C</button>
-      <button class="ctrl-btn small" data-key="escape" title="Back / Escape">✕</button>
-      <button class="ctrl-btn wide"  data-key="f1"     title="Help (F1)">Help</button>
-    </div>
-  </div>
+<script>
+  "use strict";
 
-  <script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/lib/xterm-addon-fit.js"></script>
-  <script>
-    const WS_PORT = 8765;
+  const WS_PORT = 8765;
 
-    const KEY_SEQUENCES = {
-      up:     "\x1b[A",
-      down:   "\x1b[B",
-      right:  "\x1b[C",
-      left:   "\x1b[D",
-      enter:  "\r",
-      escape: "\x1b",
-      f1:     "\x1bOP",
-      g: "g", f: "f", i: "i", c: "c",
-    };
+  const canvas   = document.getElementById("game-canvas");
+  const ctx      = canvas.getContext("2d");
+  const statusEl = document.getElementById("bar-status");
 
-    const statusEl     = document.getElementById("status");
-    const reconnectBtn = document.getElementById("reconnect");
-    const controlsEl   = document.getElementById("controls");
-
-    // ── terminal ──────────────────────────────────────────────────────────
-    const term = new Terminal({
-      theme: {
-        background:   "#111111",
-        foreground:   "#d4d4d4",
-        cursor:       "#d4d4d4",
-        black:        "#111111",
-        brightBlack:  "#555555",
-        red:          "#cc3333", brightRed:    "#ff5555",
-        green:        "#33aa33", brightGreen:  "#55cc55",
-        yellow:       "#aa8833", brightYellow: "#ffcc44",
-        cyan:         "#33aacc", brightCyan:   "#55ccff",
-        white:        "#cccccc", brightWhite:  "#ffffff",
-      },
-      fontFamily:   "'Courier New', Courier, monospace",
-      fontSize:     14,
-      cursorBlink:  false,
-      convertEol:   false,
-      scrollback:   0,  // no scroll buffer — game redraws the whole frame
-    });
-
-    const fitAddon = new FitAddon.FitAddon();
-    term.loadAddon(fitAddon);
-    term.open(document.getElementById("terminal"));
-
-    // ── touch detection — show controls, then refit to account for them ───
-    function isTouchDevice() {
-      return "ontouchstart" in window || navigator.maxTouchPoints > 0;
+  // ── image cache ────────────────────────────────────────────────────────────
+  const imgCache = {};
+  function cachedImg(path) {
+    if (!imgCache[path]) {
+      const im = new Image();
+      im.src = "/" + path;
+      imgCache[path] = im;
     }
+    return imgCache[path];
+  }
 
-    if (isTouchDevice()) {
-      controlsEl.style.display = "flex";
-      // Disable xterm's input proxy so tapping the canvas doesn't trigger the
-      // virtual keyboard.  All input on mobile goes through on-screen buttons
-      // (which call send() directly) or tap-to-interact (mouse events).
-      term.options.disableStdin = true;
-    } else {
-      term.focus();
-    }
+  // ── game dimensions (server's coordinate space for the current session) ────
+  let gameW = 800, gameH = 600;
 
-    // ── FitAddon — resize terminal to fill its container ──────────────────
-    // Run after the controls (if any) are visible so the container height is
-    // correct.  requestAnimationFrame lets the browser do one layout pass first.
-    function fitAndNotify() {
-      requestAnimationFrame(() => {
-        try { fitAddon.fit(); } catch (_) {}
-        sendResize();
-      });
-    }
+  // ── canvas sizing ──────────────────────────────────────────────────────────
+  function resizeCanvas() {
+    const wrap = canvas.parentElement;
+    const dpr  = window.devicePixelRatio || 1;
+    canvas.width  = Math.floor(wrap.clientWidth  * dpr);
+    canvas.height = Math.floor(wrap.clientHeight * dpr);
+    ctx.scale(dpr, dpr);   // compensate so CSS pixel = one game unit from here on
+    sendResize();
+  }
 
-    // Send the xterm resize report (CSI 8 ; rows ; cols t) so the server's
-    // WebRenderer re-creates its grid at the actual terminal dimensions.
-    function sendResize() {
-      if (ws && ws.readyState === WebSocket.OPEN) {
-        ws.send(`\x1b[8;${term.rows};${term.cols}t`);
+  function sendResize() {
+    const dpr = window.devicePixelRatio || 1;
+    const w   = Math.floor(canvas.parentElement.clientWidth  * dpr);
+    const h   = Math.floor(canvas.parentElement.clientHeight * dpr);
+    sendJSON({ type: "resize", w, h });
+  }
+
+  window.addEventListener("resize", () => {
+    // After resize, the DPR scale set in resizeCanvas is reset; redo it.
+    resizeCanvas();
+  });
+
+  // ── frame rendering ────────────────────────────────────────────────────────
+  function renderFrame(raw) {
+    let frame;
+    try { frame = JSON.parse(raw); } catch { return; }
+    if (frame.type !== "frame") return;
+
+    gameW = frame.w;
+    gameH = frame.h;
+
+    const dpr   = window.devicePixelRatio || 1;
+    const cssW  = canvas.clientWidth;
+    const cssH  = canvas.clientHeight;
+    const scaleX = cssW / gameW;
+    const scaleY = cssH / gameH;
+
+    ctx.save();
+    ctx.scale(scaleX, scaleY);
+
+    let clipDepth = 0;
+
+    for (const c of frame.calls) {
+      switch (c.op) {
+
+        case "clear":
+          ctx.fillStyle = rgb(c.color);
+          ctx.fillRect(0, 0, gameW, gameH);
+          break;
+
+        case "rect":
+          ctx.fillStyle = rgb(c.color);
+          ctx.fillRect(c.x, c.y, c.w, c.h);
+          break;
+
+        case "img": {
+          const im = cachedImg(c.path);
+          ctx.drawImage(im, c.x, c.y, c.w || 32, c.h || 32);
+          break;
+        }
+
+        case "text": {
+          ctx.font         = `${c.size}px monospace`;
+          ctx.fillStyle    = rgb(c.color);
+          ctx.textAlign    = c.align === "l" ? "left" : "center";
+          ctx.textBaseline = "middle";
+          ctx.fillText(c.text, c.x, c.y);
+          break;
+        }
+
+        case "button": {
+          // Box fill
+          ctx.fillStyle = rgb(c.bc || [40, 40, 40]);
+          ctx.fillRect(c.x, c.y, c.w, c.h);
+          // Border
+          ctx.strokeStyle = "#666";
+          ctx.lineWidth   = 2;
+          ctx.strokeRect(c.x + 1, c.y + 1, c.w - 2, c.h - 2);
+          // Label
+          const fs = Math.min(Math.floor(c.h * 0.42), 28);
+          ctx.font         = `bold ${fs}px sans-serif`;
+          ctx.fillStyle    = rgb(c.tc || [255, 255, 255]);
+          ctx.textAlign    = "center";
+          ctx.textBaseline = "middle";
+          ctx.fillText(c.text, c.x + c.w / 2, c.y + c.h / 2);
+          break;
+        }
+
+        case "overlay": {
+          const [r, g, b, a = 128] = c.color;
+          ctx.fillStyle = `rgba(${r},${g},${b},${a / 255})`;
+          ctx.fillRect(0, 0, gameW, gameH);
+          break;
+        }
+
+        case "daynight":
+          renderDayNight(c);
+          break;
+
+        case "clip":
+          ctx.save();
+          ctx.beginPath();
+          ctx.rect(c.x, c.y, c.w, c.h);
+          ctx.clip();
+          clipDepth++;
+          break;
+
+        case "unclip":
+          if (clipDepth > 0) { ctx.restore(); clipDepth--; }
+          break;
       }
     }
 
-    window.addEventListener("resize", fitAndNotify);
-    // Initial fit — called before connect() so size is known at WS open.
-    fitAndNotify();
+    // Restore any unclosed clip saves
+    while (clipDepth-- > 0) ctx.restore();
+    ctx.restore();  // undo scale(scaleX, scaleY)
+  }
 
-    // ── WebSocket ─────────────────────────────────────────────────────────
-    let ws = null;
+  function renderDayNight(c) {
+    const [gx, gy, gw, gh] = c.rect;
+    const alpha = c.opacity / 255;
+    if (alpha < 0.05) return;
 
-    function send(data) {
-      if (ws && ws.readyState === WebSocket.OPEN) ws.send(data);
+    const oc   = new OffscreenCanvas(gw, gh);
+    const oc2d = oc.getContext("2d");
+
+    oc2d.fillStyle = `rgba(0,0,20,${alpha})`;
+    oc2d.fillRect(0, 0, gw, gh);
+
+    oc2d.globalCompositeOperation = "destination-out";
+    for (const [sx, sy, r] of c.lights) {
+      const lx   = sx - gx;
+      const ly   = sy - gy;
+      const grad = oc2d.createRadialGradient(lx, ly, 0, lx, ly, r);
+      grad.addColorStop(0,   "rgba(0,0,0,1)");
+      grad.addColorStop(0.5, "rgba(0,0,0,0.8)");
+      grad.addColorStop(1,   "rgba(0,0,0,0)");
+      oc2d.fillStyle = grad;
+      oc2d.beginPath();
+      oc2d.arc(lx, ly, r, 0, Math.PI * 2);
+      oc2d.fill();
     }
 
-    function setStatus(msg, isError) {
-      statusEl.textContent = msg;
-      statusEl.style.color = isError ? "#cc5555" : "#888";
-    }
+    ctx.drawImage(oc, gx, gy);
+  }
 
-    function connect() {
-      if (ws && ws.readyState === WebSocket.OPEN) ws.close();
-      reconnectBtn.style.display = "none";
-      setStatus("Connecting…");
+  function rgb([r, g, b]) { return `rgb(${r},${g},${b})`; }
 
-      ws = new WebSocket(`ws://${location.hostname}:${WS_PORT}`);
+  // ── WebSocket ──────────────────────────────────────────────────────────────
+  let ws = null;
 
-      ws.onopen = () => {
-        setStatus("Connected");
-        term.reset();
-        // Tell the server the actual terminal size immediately.
-        sendResize();
-        if (!isTouchDevice()) term.focus();
-      };
+  function send(data) {
+    if (ws && ws.readyState === WebSocket.OPEN) ws.send(data);
+  }
+  function sendJSON(obj) { send(JSON.stringify(obj)); }
 
-      ws.onmessage = (evt) => term.write(evt.data);
+  function setStatus(msg, isError) {
+    statusEl.textContent = msg;
+    statusEl.style.color = isError ? "#c55" : "#666";
+  }
 
-      ws.onclose = () => {
-        setStatus("Disconnected.", true);
-        reconnectBtn.style.display = "inline-block";
-      };
+  function connect() {
+    if (ws && ws.readyState !== WebSocket.CLOSED) ws.close();
+    setStatus("Connecting…");
+    ws = new WebSocket(`ws://${location.hostname}:${WS_PORT}`);
+    ws.onopen    = () => { setStatus("Connected"); sendResize(); };
+    ws.onmessage = (e) => renderFrame(e.data);
+    ws.onclose   = () => setStatus("Disconnected — click Reconnect to retry", true);
+    ws.onerror   = () => setStatus(`Cannot reach ${location.hostname}:${WS_PORT}`, true);
+  }
 
-      ws.onerror = () => {
-        setStatus(`Error — server on port ${WS_PORT}?`, true);
-        reconnectBtn.style.display = "inline-block";
-      };
+  // ── touch detection ────────────────────────────────────────────────────────
+  function isTouchDevice() {
+    return "ontouchstart" in window || navigator.maxTouchPoints > 0;
+  }
 
-      term.onData((data) => send(data));
-    }
+  // ── key sequences (ANSI — parsed by TextInputSource on the server) ─────────
+  const KEY_SEQS = {
+    ArrowUp: "\x1b[A", ArrowDown: "\x1b[B", ArrowRight: "\x1b[C", ArrowLeft: "\x1b[D",
+    Enter: "\r", Escape: "\x1b", F1: "\x1bOP", F2: "\x1bOQ", F3: "\x1bOR",
+    Backspace: "\x7f",
+    // D-pad button data-key aliases
+    up: "\x1b[A", down: "\x1b[B", right: "\x1b[C", left: "\x1b[D",
+    enter: "\r", escape: "\x1b", f1: "\x1bOP",
+  };
+  const REPEAT_KEYS = new Set(["up", "down", "left", "right",
+                                "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"]);
 
-    // ── on-screen button wiring ───────────────────────────────────────────
-    // Directional keys repeat at 120 ms while held so the player can walk
-    // continuously by holding the button instead of tapping for every step.
-    // Action keys (G, F, I, C, Esc, Help) fire once per touch.
-    const REPEAT_KEYS = new Set(["up", "down", "left", "right"]);
-
-    let _repeatTimer = null;
-    function _startKey(seq, repeats) {
-      send(seq);
-      if (repeats) {
-        clearInterval(_repeatTimer);
-        _repeatTimer = setInterval(() => send(seq), 120);
-      }
-    }
-    function _stopKey() {
+  // ── key repeat (D-pad hold) ────────────────────────────────────────────────
+  let _repeatTimer = null;
+  function startKey(key, seq) {
+    send(seq);
+    if (REPEAT_KEYS.has(key)) {
       clearInterval(_repeatTimer);
-      _repeatTimer = null;
+      _repeatTimer = setInterval(() => send(seq), 120);
     }
+  }
+  function stopKey() {
+    clearInterval(_repeatTimer);
+    _repeatTimer = null;
+  }
 
-    document.querySelectorAll(".ctrl-btn").forEach((btn) => {
-      const key  = btn.dataset.key;
-      const seq  = KEY_SEQUENCES[key];
-      if (!seq) return;
-      const repeats = REPEAT_KEYS.has(key);
-      btn.addEventListener("touchstart",  (e) => { e.preventDefault(); _startKey(seq, repeats); }, { passive: false });
-      btn.addEventListener("touchend",    (e) => { e.preventDefault(); _stopKey(); },              { passive: false });
-      btn.addEventListener("touchcancel", (e) => { e.preventDefault(); _stopKey(); },              { passive: false });
-      btn.addEventListener("mousedown",   (e) => { e.preventDefault(); _startKey(seq, repeats); });
-      btn.addEventListener("mouseup",     () => _stopKey());
-      btn.addEventListener("mouseleave",  () => _stopKey());
-    });
-
-    // ── tap-to-interact ───────────────────────────────────────────────────
-    // Convert a browser-pixel position inside the xterm canvas to the game's
-    // pixel coordinate system (server uses cellWidth=8, cellHeight=16).
-    // The mapping: browser tap → character cell (col,row) → game pixels.
-    function terminalGamePixels(clientX, clientY) {
-      const screen = document.querySelector(".xterm-screen");
-      if (!screen) return null;
-      const rect  = screen.getBoundingClientRect();
-      const bx    = clientX - rect.left;
-      const by    = clientY - rect.top;
-      const cellW = rect.width  / term.cols;
-      const cellH = rect.height / term.rows;
-      const col   = Math.floor(bx / cellW);
-      const row   = Math.floor(by / cellH);
-      return { x: col * 8, y: row * 16 };   // 8/16 = server's cellWidth/cellHeight
-    }
-
-    function sendMouse(type, clientX, clientY, button) {
-      const gp = terminalGamePixels(clientX, clientY);
-      if (gp) send(JSON.stringify({ type, x: gp.x, y: gp.y, button }));
-    }
-
-    const termOuter = document.getElementById("terminal-outer");
-
-    // Touch: tap or long-press on the game canvas
-    let _tapTimer    = null;
-    let _tapStart    = null;
-    let _longPressed = false;
-
-    termOuter.addEventListener("touchstart", (e) => {
-      // Ignore multi-touch — we only handle single-finger taps
-      if (e.touches.length !== 1) return;
+  // ── desktop keyboard ───────────────────────────────────────────────────────
+  document.addEventListener("keydown", (e) => {
+    if (e.ctrlKey || e.metaKey) return;
+    const seq = KEY_SEQS[e.key];
+    if (seq) {
       e.preventDefault();
-      const t = e.touches[0];
-      _tapStart    = { x: t.clientX, y: t.clientY };
-      _longPressed = false;
-
-      // Long-press (≥450 ms) → right-click → place/interact
-      _tapTimer = setTimeout(() => {
-        _longPressed = true;
-        sendMouse("mouse_down", _tapStart.x, _tapStart.y, 3);  // button 3 = right
-      }, 450);
-    }, { passive: false });
-
-    termOuter.addEventListener("touchend", (e) => {
+      startKey(e.key, seq);
+      return;
+    }
+    if (!e.altKey && e.key.length === 1) {
       e.preventDefault();
-      clearTimeout(_tapTimer);
-      if (_longPressed) {
-        const t = e.changedTouches[0];
-        sendMouse("mouse_up", t.clientX, t.clientY, 3);
-      } else if (_tapStart) {
-        // Short tap → left-click → gather
-        sendMouse("mouse_down", _tapStart.x, _tapStart.y, 1);
-        // Release immediately so setGathering is cleared on the next frame
-        setTimeout(() => sendMouse("mouse_up", _tapStart.x, _tapStart.y, 1), 80);
-      }
-      _tapStart = null;
-    }, { passive: false });
+      send(e.key);
+    }
+  });
+  document.addEventListener("keyup", (e) => {
+    if (REPEAT_KEYS.has(e.key)) stopKey();
+  });
 
-    // Desktop mouse clicks on the terminal (same code path, different trigger)
-    termOuter.addEventListener("mousedown", (e) => {
-      // button 0=left, 2=right in MouseEvent; map to SDL 1=left, 3=right
-      const btn = e.button === 2 ? 3 : 1;
-      sendMouse("mouse_down", e.clientX, e.clientY, btn);
-    });
-    termOuter.addEventListener("mouseup", (e) => {
-      const btn = e.button === 2 ? 3 : 1;
-      sendMouse("mouse_up", e.clientX, e.clientY, btn);
-    });
-    // Prevent context-menu on right-click so the right-click reaches the game
-    termOuter.addEventListener("contextmenu", (e) => e.preventDefault());
+  // ── on-screen buttons ──────────────────────────────────────────────────────
+  document.querySelectorAll(".btn[data-key]").forEach((btn) => {
+    const key  = btn.dataset.key;
+    const seq  = KEY_SEQS[key];
+    if (!seq) return;
+    const rep = REPEAT_KEYS.has(key);
 
-    connect();
-  </script>
+    btn.addEventListener("touchstart",  (e) => { e.preventDefault(); btn.classList.add("pressed");    startKey(key, seq); }, { passive: false });
+    btn.addEventListener("touchend",    (e) => { e.preventDefault(); btn.classList.remove("pressed"); stopKey(); },          { passive: false });
+    btn.addEventListener("touchcancel", (e) => { e.preventDefault(); btn.classList.remove("pressed"); stopKey(); },          { passive: false });
+    btn.addEventListener("mousedown",   (e) => { e.preventDefault(); btn.classList.add("pressed");    startKey(key, seq); });
+    btn.addEventListener("mouseup",     ()  => { btn.classList.remove("pressed"); stopKey(); });
+    btn.addEventListener("mouseleave",  ()  => { btn.classList.remove("pressed"); stopKey(); });
+  });
+
+  // ── tap-to-interact ────────────────────────────────────────────────────────
+  // Convert a browser-pixel position on the canvas to the server's game-pixel
+  // coordinate space.  gameW / gameH are updated each frame from the server.
+  function canvasToGame(clientX, clientY) {
+    const rect = canvas.getBoundingClientRect();
+    const bx = clientX - rect.left;
+    const by = clientY - rect.top;
+    return {
+      x: Math.round(bx * gameW / rect.width),
+      y: Math.round(by * gameH / rect.height),
+    };
+  }
+
+  function sendMouseEvent(type, clientX, clientY, button) {
+    const gp = canvasToGame(clientX, clientY);
+    sendJSON({ type, x: gp.x, y: gp.y, button });
+  }
+
+  const canvasWrap = document.getElementById("canvas-wrap");
+
+  // Touch: short tap = left-click (gather/select); long-press = right-click (place)
+  let _tapTimer = null, _tapStart = null, _tapLong = false;
+
+  canvasWrap.addEventListener("touchstart", (e) => {
+    if (e.touches.length !== 1) return;
+    e.preventDefault();
+    const t    = e.touches[0];
+    _tapStart  = { x: t.clientX, y: t.clientY };
+    _tapLong   = false;
+    _tapTimer  = setTimeout(() => {
+      _tapLong = true;
+      sendMouseEvent("mouse_down", _tapStart.x, _tapStart.y, 3);
+    }, 450);
+  }, { passive: false });
+
+  canvasWrap.addEventListener("touchend", (e) => {
+    e.preventDefault();
+    clearTimeout(_tapTimer);
+    if (_tapLong) {
+      const t = e.changedTouches[0];
+      sendMouseEvent("mouse_up", t.clientX, t.clientY, 3);
+    } else if (_tapStart) {
+      sendMouseEvent("mouse_down", _tapStart.x, _tapStart.y, 1);
+      setTimeout(() => sendMouseEvent("mouse_up", _tapStart.x, _tapStart.y, 1), 60);
+    }
+    _tapStart = null;
+  }, { passive: false });
+
+  canvasWrap.addEventListener("touchcancel", (e) => {
+    clearTimeout(_tapTimer);
+    _tapStart = null;
+  }, { passive: false });
+
+  // Desktop mouse
+  canvasWrap.addEventListener("mousedown", (e) => {
+    const btn = e.button === 2 ? 3 : 1;
+    sendMouseEvent("mouse_down", e.clientX, e.clientY, btn);
+  });
+  canvasWrap.addEventListener("mouseup", (e) => {
+    const btn = e.button === 2 ? 3 : 1;
+    sendMouseEvent("mouse_up", e.clientX, e.clientY, btn);
+  });
+  canvasWrap.addEventListener("contextmenu", (e) => e.preventDefault());
+
+  // ── init ────────────────────────────────────────────────────────────────────
+  if (isTouchDevice()) {
+    document.getElementById("controls").style.display = "flex";
+  }
+
+  resizeCanvas();
+  connect();
+</script>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -201,6 +201,10 @@
 
     if (isTouchDevice()) {
       controlsEl.style.display = "flex";
+      // Disable xterm's input proxy so tapping the canvas doesn't trigger the
+      // virtual keyboard.  All input on mobile goes through on-screen buttons
+      // (which call send() directly) or tap-to-interact (mouse events).
+      term.options.disableStdin = true;
     } else {
       term.focus();
     }
@@ -270,11 +274,35 @@
     }
 
     // ── on-screen button wiring ───────────────────────────────────────────
+    // Directional keys repeat at 120 ms while held so the player can walk
+    // continuously by holding the button instead of tapping for every step.
+    // Action keys (G, F, I, C, Esc, Help) fire once per touch.
+    const REPEAT_KEYS = new Set(["up", "down", "left", "right"]);
+
+    let _repeatTimer = null;
+    function _startKey(seq, repeats) {
+      send(seq);
+      if (repeats) {
+        clearInterval(_repeatTimer);
+        _repeatTimer = setInterval(() => send(seq), 120);
+      }
+    }
+    function _stopKey() {
+      clearInterval(_repeatTimer);
+      _repeatTimer = null;
+    }
+
     document.querySelectorAll(".ctrl-btn").forEach((btn) => {
-      const seq = KEY_SEQUENCES[btn.dataset.key];
+      const key  = btn.dataset.key;
+      const seq  = KEY_SEQUENCES[key];
       if (!seq) return;
-      btn.addEventListener("touchstart", (e) => { e.preventDefault(); send(seq); }, { passive: false });
-      btn.addEventListener("mousedown",  (e) => { e.preventDefault(); send(seq); });
+      const repeats = REPEAT_KEYS.has(key);
+      btn.addEventListener("touchstart",  (e) => { e.preventDefault(); _startKey(seq, repeats); }, { passive: false });
+      btn.addEventListener("touchend",    (e) => { e.preventDefault(); _stopKey(); },              { passive: false });
+      btn.addEventListener("touchcancel", (e) => { e.preventDefault(); _stopKey(); },              { passive: false });
+      btn.addEventListener("mousedown",   (e) => { e.preventDefault(); _startKey(seq, repeats); });
+      btn.addEventListener("mouseup",     () => _stopKey());
+      btn.addEventListener("mouseleave",  () => _stopKey());
     });
 
     // ── tap-to-interact ───────────────────────────────────────────────────

--- a/web/index.html
+++ b/web/index.html
@@ -20,7 +20,7 @@
       touch-action: none;
     }
 
-    /* ── top status bar ──────────────────────────────────────────────────── */
+    /* ── status bar ──────────────────────────────────────────────────────── */
     #bar {
       flex-shrink: 0;
       background: #111;
@@ -30,10 +30,18 @@
       display: flex;
       align-items: center;
       gap: 10px;
+      overflow: hidden;
+      transition: height 0.25s ease, padding 0.25s ease, border-bottom-width 0.25s ease;
+    }
+    #bar.hidden {
+      height: 0 !important;
+      padding-top: 0;
+      padding-bottom: 0;
+      border-bottom-width: 0;
     }
     #bar-status { flex: 1; color: #666; }
     #bar-reconnect {
-      display: none;   /* hidden until disconnected */
+      display: none;
       background: #1e1e1e;
       border: 1px solid #444;
       color: #aaa;
@@ -71,22 +79,18 @@
       gap: 12px;
     }
 
-    /* D-pad: 3×3 grid with corners empty */
     .dpad {
       display: grid;
       grid-template-columns: repeat(3, 48px);
       grid-template-rows: repeat(3, 48px);
       gap: 4px;
     }
-
-    /* Action buttons: 3×2 grid */
     .actions {
       display: grid;
       grid-template-columns: repeat(3, 48px);
       grid-template-rows: repeat(2, 48px);
       gap: 4px;
     }
-
     .btn {
       background: #1c1c1c;
       border: 1px solid #333;
@@ -111,18 +115,15 @@
 </head>
 <body>
 
-<!-- status bar -->
 <div id="bar">
   <span id="bar-status">Connecting…</span>
   <button id="bar-reconnect" onclick="connect()">Reconnect</button>
 </div>
 
-<!-- game canvas -->
 <div id="canvas-wrap">
   <canvas id="game-canvas"></canvas>
 </div>
 
-<!-- mobile on-screen controls (touch devices only) -->
 <div id="controls">
   <div class="dpad">
     <div class="dpad-spacer"></div>
@@ -152,9 +153,12 @@
 
   const canvas      = document.getElementById("game-canvas");
   const ctx         = canvas.getContext("2d");
+  const barEl       = document.getElementById("bar");
   const statusEl    = document.getElementById("bar-status");
   const reconnectEl = document.getElementById("bar-reconnect");
   const canvasWrap  = document.getElementById("canvas-wrap");
+
+  const _isTouch = "ontouchstart" in window || navigator.maxTouchPoints > 0;
 
   // ── image cache ────────────────────────────────────────────────────────────
   const imgCache = {};
@@ -167,7 +171,7 @@
     return imgCache[path];
   }
 
-  // ── game dimensions (server's coordinate space for the current session) ────
+  // ── game dimensions ────────────────────────────────────────────────────────
   let gameW = 800, gameH = 600;
 
   // ── canvas sizing ──────────────────────────────────────────────────────────
@@ -176,7 +180,7 @@
     const dpr  = window.devicePixelRatio || 1;
     canvas.width  = Math.floor(wrap.clientWidth  * dpr);
     canvas.height = Math.floor(wrap.clientHeight * dpr);
-    ctx.scale(dpr, dpr);   // compensate so CSS pixel = one game unit from here on
+    ctx.scale(dpr, dpr);
     sendResize();
   }
 
@@ -189,11 +193,18 @@
 
   window.addEventListener("resize", resizeCanvas);
 
-  // ── loading overlay ────────────────────────────────────────────────────────
-  let _firstFrame = false;
+  // ── status bar visibility ──────────────────────────────────────────────────
+  function hideBar() {
+    barEl.classList.add("hidden");
+    setTimeout(resizeCanvas, 270);
+  }
+  function showBar() {
+    barEl.classList.remove("hidden");
+    setTimeout(resizeCanvas, 270);
+  }
 
+  // ── loading overlay ────────────────────────────────────────────────────────
   function drawLoading() {
-    const dpr  = window.devicePixelRatio || 1;
     const cssW = canvas.clientWidth;
     const cssH = canvas.clientHeight;
     ctx.save();
@@ -207,20 +218,41 @@
     ctx.restore();
   }
 
+  // ── tap-flash state ────────────────────────────────────────────────────────
+  let _tapFlash = null;  // {gx, gy, expiresAt}
+
+  function triggerFlash(clientX, clientY) {
+    const gp = canvasToGame(clientX, clientY);
+    _tapFlash = { gx: gp.x, gy: gp.y, expiresAt: Date.now() + 220 };
+  }
+
+  // ── button hover state ─────────────────────────────────────────────────────
+  let _lastMouseGP  = { x: -9999, y: -9999 };
+  let _buttonRects  = [];  // rebuilt each frame; used for cursor + hover
+
+  function updateCursor() {
+    const over = _buttonRects.some(r =>
+      _lastMouseGP.x >= r.x && _lastMouseGP.x < r.x + r.w &&
+      _lastMouseGP.y >= r.y && _lastMouseGP.y < r.y + r.h
+    );
+    canvasWrap.style.cursor = over ? "pointer" : "crosshair";
+  }
+
   // ── frame rendering ────────────────────────────────────────────────────────
   function renderFrame(raw) {
     let frame;
     try { frame = JSON.parse(raw); } catch { return; }
     if (frame.type !== "frame") return;
 
-    _firstFrame = true;
     gameW = frame.w;
     gameH = frame.h;
 
-    const cssW  = canvas.clientWidth;
-    const cssH  = canvas.clientHeight;
+    const cssW   = canvas.clientWidth;
+    const cssH   = canvas.clientHeight;
     const scaleX = cssW / gameW;
     const scaleY = cssH / gameH;
+
+    _buttonRects = [];
 
     ctx.save();
     ctx.scale(scaleX, scaleY);
@@ -247,7 +279,6 @@
           if (im.complete && im.naturalWidth > 0) {
             ctx.drawImage(im, c.x, c.y, w, h);
           } else {
-            // Placeholder tile while browser fetches the image
             ctx.fillStyle = "#222";
             ctx.fillRect(c.x, c.y, w, h);
           }
@@ -264,17 +295,44 @@
         }
 
         case "button": {
-          ctx.fillStyle = rgb(c.bc || [40, 40, 40]);
-          ctx.fillRect(c.x, c.y, c.w, c.h);
-          ctx.strokeStyle = "rgba(255,255,255,0.15)";
+          const [br, bg, bb] = c.bc || [40, 40, 40];
+          const lum = (0.299 * br + 0.587 * bg + 0.114 * bb) / 255;
+
+          // Hover brightens dark buttons, darkens light ones (desktop only)
+          const hovered = !_isTouch &&
+            _lastMouseGP.x >= c.x && _lastMouseGP.x < c.x + c.w &&
+            _lastMouseGP.y >= c.y && _lastMouseGP.y < c.y + c.h;
+          const mix = hovered ? (lum > 0.5 ? 0.82 : 1.3) : 1;
+          const fr  = Math.min(255, Math.round(br * mix));
+          const fg  = Math.min(255, Math.round(bg * mix));
+          const fb  = Math.min(255, Math.round(bb * mix));
+
+          // Rounded background
+          const radius = Math.min(5, c.w * 0.1, c.h * 0.1);
+          ctx.fillStyle = `rgb(${fr},${fg},${fb})`;
+          _roundRect(ctx, c.x, c.y, c.w, c.h, radius);
+          ctx.fill();
+
+          // Contrasting border
+          ctx.strokeStyle = lum > 0.5 ? "rgba(0,0,0,0.18)" : "rgba(255,255,255,0.15)";
           ctx.lineWidth   = 1;
-          ctx.strokeRect(c.x + 0.5, c.y + 0.5, c.w - 1, c.h - 1);
-          const fs = Math.min(Math.floor(c.h * 0.42), 28);
+          _roundRect(ctx, c.x + 0.5, c.y + 0.5, c.w - 1, c.h - 1, radius);
+          ctx.stroke();
+
+          // Text — auto-shrink to fit button width
+          let fs = Math.min(Math.floor(c.h * 0.42), 28);
           ctx.font         = `bold ${fs}px sans-serif`;
-          ctx.fillStyle    = rgb(c.tc || [255, 255, 255]);
           ctx.textAlign    = "center";
           ctx.textBaseline = "middle";
+          const tw = ctx.measureText(c.text).width;
+          if (tw > c.w - 8) {
+            fs = Math.max(8, Math.floor(fs * (c.w - 8) / tw));
+            ctx.font = `bold ${fs}px sans-serif`;
+          }
+          ctx.fillStyle = rgb(c.tc || [255, 255, 255]);
           ctx.fillText(c.text, c.x + c.w / 2, c.y + c.h / 2);
+
+          _buttonRects.push({ x: c.x, y: c.y, w: c.w, h: c.h });
           break;
         }
 
@@ -303,9 +361,38 @@
       }
     }
 
-    // Restore any unclosed clip saves
     while (clipDepth-- > 0) ctx.restore();
+
+    // Tap-flash overlay (game coordinate space, over everything else)
+    if (_tapFlash) {
+      const now = Date.now();
+      if (now < _tapFlash.expiresAt) {
+        const progress = (_tapFlash.expiresAt - now) / 220;
+        ctx.save();
+        ctx.globalAlpha = 0.38 * progress;
+        ctx.fillStyle   = "white";
+        ctx.beginPath();
+        ctx.arc(_tapFlash.gx, _tapFlash.gy, 24, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.restore();
+      } else {
+        _tapFlash = null;
+      }
+    }
+
     ctx.restore();  // undo scale(scaleX, scaleY)
+
+    // Update pointer cursor based on freshly built _buttonRects
+    if (!_isTouch) updateCursor();
+  }
+
+  function _roundRect(ctx, x, y, w, h, r) {
+    ctx.beginPath();
+    if (ctx.roundRect) {
+      ctx.roundRect(x, y, w, h, r);
+    } else {
+      ctx.rect(x, y, w, h);
+    }
   }
 
   function renderDayNight(c) {
@@ -353,45 +440,42 @@
 
   function connect() {
     if (ws && ws.readyState !== WebSocket.CLOSED) ws.close();
-    _firstFrame = false;
     setStatus("Connecting…");
-    reconnectEl.style.display = "none";
+    showBar();
     ws = new WebSocket(`ws://${location.hostname}:${WS_PORT}`);
-    ws.onopen    = () => {
+    ws.onopen = () => {
       setStatus("Connected");
       reconnectEl.style.display = "none";
-      sendResize();
-      drawLoading();
+      // Collapse bar after a beat, then send the larger resize
+      setTimeout(() => {
+        hideBar();
+        setTimeout(() => { resizeCanvas(); drawLoading(); }, 270);
+      }, 600);
     };
     ws.onmessage = (e) => renderFrame(e.data);
     ws.onclose   = () => {
       setStatus("Disconnected — tap Reconnect to retry", true);
       reconnectEl.style.display = "";
+      showBar();
     };
     ws.onerror   = () => {
       setStatus(`Cannot reach ${location.hostname}:${WS_PORT}`, true);
       reconnectEl.style.display = "";
+      showBar();
     };
   }
 
-  // ── touch detection ────────────────────────────────────────────────────────
-  function isTouchDevice() {
-    return "ontouchstart" in window || navigator.maxTouchPoints > 0;
-  }
-
-  // ── key sequences (ANSI — parsed by TextInputSource on the server) ─────────
+  // ── key sequences ──────────────────────────────────────────────────────────
   const KEY_SEQS = {
     ArrowUp: "\x1b[A", ArrowDown: "\x1b[B", ArrowRight: "\x1b[C", ArrowLeft: "\x1b[D",
     Enter: "\r", Escape: "\x1b", F1: "\x1bOP", F2: "\x1bOQ", F3: "\x1bOR",
     Backspace: "\x7f",
-    // D-pad button data-key aliases
     up: "\x1b[A", down: "\x1b[B", right: "\x1b[C", left: "\x1b[D",
     enter: "\r", escape: "\x1b", f1: "\x1bOP",
   };
   const REPEAT_KEYS = new Set(["up", "down", "left", "right",
                                 "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"]);
 
-  // ── key repeat (D-pad hold) ────────────────────────────────────────────────
   let _repeatTimer = null;
   function startKey(key, seq) {
     send(seq);
@@ -409,15 +493,8 @@
   document.addEventListener("keydown", (e) => {
     if (e.ctrlKey || e.metaKey) return;
     const seq = KEY_SEQS[e.key];
-    if (seq) {
-      e.preventDefault();
-      startKey(e.key, seq);
-      return;
-    }
-    if (!e.altKey && e.key.length === 1) {
-      e.preventDefault();
-      send(e.key);
-    }
+    if (seq) { e.preventDefault(); startKey(e.key, seq); return; }
+    if (!e.altKey && e.key.length === 1) { e.preventDefault(); send(e.key); }
   });
   document.addEventListener("keyup", (e) => {
     if (REPEAT_KEYS.has(e.key)) stopKey();
@@ -425,9 +502,8 @@
 
   // ── on-screen buttons ──────────────────────────────────────────────────────
   document.querySelectorAll(".btn[data-key]").forEach((btn) => {
-    const key  = btn.dataset.key;
-    const seq  = KEY_SEQS[key];
-    if (!seq) return;
+    const key = btn.dataset.key;
+    const seq = KEY_SEQS[key] || key;
 
     btn.addEventListener("touchstart",  (e) => { e.preventDefault(); btn.classList.add("pressed");    startKey(key, seq); }, { passive: false });
     btn.addEventListener("touchend",    (e) => { e.preventDefault(); btn.classList.remove("pressed"); stopKey(); },          { passive: false });
@@ -437,14 +513,12 @@
     btn.addEventListener("mouseleave",  ()  => { btn.classList.remove("pressed"); stopKey(); });
   });
 
-  // ── mouse coordinate conversion ────────────────────────────────────────────
+  // ── coordinate conversion ──────────────────────────────────────────────────
   function canvasToGame(clientX, clientY) {
     const rect = canvas.getBoundingClientRect();
-    const bx = clientX - rect.left;
-    const by = clientY - rect.top;
     return {
-      x: Math.round(bx * gameW / rect.width),
-      y: Math.round(by * gameH / rect.height),
+      x: Math.round((clientX - rect.left) * gameW / rect.width),
+      y: Math.round((clientY - rect.top)  * gameH / rect.height),
     };
   }
 
@@ -455,17 +529,14 @@
 
   function sendMouseMove(clientX, clientY) {
     const gp = canvasToGame(clientX, clientY);
+    _lastMouseGP = gp;
     sendJSON({ type: "mouse_move", x: gp.x, y: gp.y });
   }
 
   // ── tap-to-interact ────────────────────────────────────────────────────────
-  // Gesture states:
-  //   short tap  (<450ms, <5px move) → left click (gather / select button)
-  //   long press (≥450ms, <5px move) → right click (place)
-  //   drag       (≥5px move)         → left-click-drag (HUD repositioning)
-  let _tapTimer  = null;
-  let _tapStart  = null;
-  let _tapLong   = false;
+  let _tapTimer   = null;
+  let _tapStart   = null;
+  let _tapLong    = false;
   let _dragActive = false;
   let _lastMoveSent = 0;
 
@@ -494,7 +565,6 @@
         clearTimeout(_tapTimer);
         _tapLong    = false;
         _dragActive = true;
-        // Send mouse_down at original touch position to start the drag
         sendMouseEvent("mouse_down", _tapStart.x, _tapStart.y, 1);
       }
     }
@@ -517,7 +587,7 @@
     } else if (_dragActive) {
       sendMouseEvent("mouse_up", t.clientX, t.clientY, 1);
     } else if (_tapStart) {
-      // Short tap: fire click at original touch-down position
+      triggerFlash(_tapStart.x, _tapStart.y);
       sendMouseEvent("mouse_down", _tapStart.x, _tapStart.y, 1);
       setTimeout(() => sendMouseEvent("mouse_up", _tapStart.x, _tapStart.y, 1), 60);
     }
@@ -540,13 +610,15 @@
   // Desktop mouse
   canvasWrap.addEventListener("mousedown", (e) => {
     const btn = e.button === 2 ? 3 : 1;
+    if (btn === 1) triggerFlash(e.clientX, e.clientY);
     sendMouseEvent("mouse_down", e.clientX, e.clientY, btn);
   });
   canvasWrap.addEventListener("mouseup", (e) => {
-    const btn = e.button === 2 ? 3 : 1;
-    sendMouseEvent("mouse_up", e.clientX, e.clientY, btn);
+    sendMouseEvent("mouse_up", e.clientX, e.clientY, e.button === 2 ? 3 : 1);
   });
   canvasWrap.addEventListener("mousemove", (e) => {
+    _lastMouseGP = canvasToGame(e.clientX, e.clientY);
+    updateCursor();
     const now = Date.now();
     if (now - _lastMoveSent < 40) return;
     _lastMoveSent = now;
@@ -555,10 +627,7 @@
   canvasWrap.addEventListener("contextmenu", (e) => e.preventDefault());
 
   // ── init ────────────────────────────────────────────────────────────────────
-  if (isTouchDevice()) {
-    document.getElementById("controls").style.display = "flex";
-  }
-
+  if (_isTouch) document.getElementById("controls").style.display = "flex";
   resizeCanvas();
   connect();
 </script>

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,274 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <title>Roam</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.css" />
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      background: #111;
+      color: #ccc;
+      font-family: "Courier New", Courier, monospace;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 8px 4px 12px;
+      min-height: 100dvh;
+      gap: 6px;
+      overflow-x: hidden;
+    }
+
+    h1 { font-size: 1.3rem; letter-spacing: 0.12em; color: #e8c97a; }
+
+    #status {
+      font-size: 0.8rem;
+      color: #888;
+      min-height: 1.1em;
+      text-align: center;
+    }
+
+    /* ── terminal ── */
+    #terminal-wrap {
+      border: 1px solid #2a2a2a;
+      border-radius: 4px;
+      overflow: auto;           /* allow pinch-zoom to reveal clipped content */
+      touch-action: pinch-zoom; /* browser handles pinch; we handle tap via buttons */
+      max-width: 100%;
+    }
+
+    /* ── on-screen controls (shown only on touch devices via JS) ── */
+    #controls {
+      display: none;
+      flex-direction: column;
+      align-items: center;
+      gap: 4px;
+      width: 100%;
+      max-width: 400px;
+      margin-top: 4px;
+    }
+
+    .btn-row {
+      display: flex;
+      gap: 6px;
+      justify-content: center;
+    }
+
+    .ctrl-btn {
+      background: #1e1e1e;
+      color: #ddd;
+      border: 1px solid #444;
+      border-radius: 6px;
+      font-family: inherit;
+      font-size: 1.1rem;
+      cursor: pointer;
+      /* comfortable tap target */
+      min-width: 52px;
+      min-height: 52px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      user-select: none;
+      -webkit-user-select: none;
+      touch-action: manipulation;
+    }
+    .ctrl-btn:active { background: #333; border-color: #e8c97a; color: #e8c97a; }
+
+    .ctrl-btn.wide  { min-width: 110px; font-size: 0.85rem; }
+    .ctrl-btn.small { min-width: 44px; min-height: 44px; font-size: 0.8rem; }
+
+    /* spacer cell in the D-pad grid */
+    .ctrl-spacer { min-width: 52px; min-height: 52px; }
+
+    /* ── action button strip ── */
+    #action-row { flex-wrap: wrap; justify-content: center; gap: 6px; }
+
+    /* ── status / reconnect ── */
+    #reconnect {
+      display: none;
+      padding: 6px 18px;
+      background: #2a2a2a;
+      color: #e8c97a;
+      border: 1px solid #555;
+      border-radius: 3px;
+      cursor: pointer;
+      font-family: inherit;
+      font-size: 0.85rem;
+    }
+    #reconnect:hover, #reconnect:active { background: #3a3a3a; }
+
+    footer { font-size: 0.7rem; color: #444; text-align: center; }
+  </style>
+</head>
+<body>
+  <h1>Roam</h1>
+  <div id="status">Connecting&hellip;</div>
+
+  <div id="terminal-wrap">
+    <div id="terminal"></div>
+  </div>
+
+  <!-- On-screen controls — shown automatically on touch devices -->
+  <div id="controls">
+    <!-- D-pad -->
+    <div class="btn-row">
+      <div class="ctrl-spacer"></div>
+      <button class="ctrl-btn" data-key="up"    title="Up">▲</button>
+      <div class="ctrl-spacer"></div>
+    </div>
+    <div class="btn-row">
+      <button class="ctrl-btn" data-key="left"  title="Left">◀</button>
+      <button class="ctrl-btn" data-key="enter" title="Interact / Confirm">✔</button>
+      <button class="ctrl-btn" data-key="right" title="Right">▶</button>
+    </div>
+    <div class="btn-row">
+      <div class="ctrl-spacer"></div>
+      <button class="ctrl-btn" data-key="down"  title="Down">▼</button>
+      <div class="ctrl-spacer"></div>
+    </div>
+
+    <!-- Action buttons -->
+    <div class="btn-row" id="action-row">
+      <button class="ctrl-btn small" data-key="g"      title="Gather (G)">G</button>
+      <button class="ctrl-btn small" data-key="f"      title="Place / Use (F)">F</button>
+      <button class="ctrl-btn small" data-key="i"      title="Inventory (I)">I</button>
+      <button class="ctrl-btn small" data-key="c"      title="Crafting (C)">C</button>
+      <button class="ctrl-btn small" data-key="escape" title="Back / Escape">✕</button>
+      <button class="ctrl-btn wide"  data-key="f1"     title="Help (F1)">Help</button>
+    </div>
+  </div>
+
+  <button id="reconnect" onclick="connect()">Reconnect</button>
+  <footer>Keyboard or on-screen controls &bull; pinch to zoom &bull; F1 for help</footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.js"></script>
+  <script>
+    const WS_PORT = 8765;
+    const COLS    = 120;
+    const ROWS    = 36;
+
+    const statusEl    = document.getElementById("status");
+    const reconnectBtn = document.getElementById("reconnect");
+    const controlsEl  = document.getElementById("controls");
+
+    // Map button data-key values to the bytes xterm.js / the server expects.
+    const KEY_SEQUENCES = {
+      up:     "\x1b[A",
+      down:   "\x1b[B",
+      right:  "\x1b[C",
+      left:   "\x1b[D",
+      enter:  "\r",
+      escape: "\x1b",
+      f1:     "\x1bOP",
+      g:      "g",
+      f:      "f",
+      i:      "i",
+      c:      "c",
+    };
+
+    // ── terminal ──────────────────────────────────────────────────────────
+    const term = new Terminal({
+      cols: COLS,
+      rows: ROWS,
+      theme: {
+        background:   "#111111",
+        foreground:   "#d4d4d4",
+        cursor:       "#d4d4d4",
+        black:        "#111111",
+        brightBlack:  "#555555",
+        red:          "#cc3333",
+        brightRed:    "#ff5555",
+        green:        "#33aa33",
+        brightGreen:  "#55cc55",
+        yellow:       "#aa8833",
+        brightYellow: "#ffcc44",
+        cyan:         "#33aacc",
+        brightCyan:   "#55ccff",
+        white:        "#cccccc",
+        brightWhite:  "#ffffff",
+      },
+      fontFamily:  "'Courier New', Courier, monospace",
+      fontSize:    14,
+      cursorBlink: false,
+      disableStdin: false,
+      convertEol:  false,
+    });
+    term.open(document.getElementById("terminal"));
+
+    // ── touch detection — show on-screen controls on touch devices ────────
+    function isTouchDevice() {
+      return "ontouchstart" in window || navigator.maxTouchPoints > 0;
+    }
+    if (isTouchDevice()) {
+      controlsEl.style.display = "flex";
+    } else {
+      term.focus();
+    }
+
+    // ── WebSocket ─────────────────────────────────────────────────────────
+    let ws = null;
+
+    function send(data) {
+      if (ws && ws.readyState === WebSocket.OPEN) ws.send(data);
+    }
+
+    function setStatus(msg, isError) {
+      statusEl.textContent = msg;
+      statusEl.style.color = isError ? "#cc5555" : "#888";
+    }
+
+    function connect() {
+      if (ws && ws.readyState === WebSocket.OPEN) ws.close();
+      reconnectBtn.style.display = "none";
+      setStatus("Connecting…");
+
+      ws = new WebSocket(`ws://${location.hostname}:${WS_PORT}`);
+
+      ws.onopen = () => {
+        setStatus("Connected");
+        term.reset();
+        if (!isTouchDevice()) term.focus();
+      };
+
+      ws.onmessage = (evt) => term.write(evt.data);
+
+      ws.onclose = () => {
+        setStatus("Disconnected.", true);
+        reconnectBtn.style.display = "inline-block";
+      };
+
+      ws.onerror = () => {
+        setStatus(`Connection error — server on port ${WS_PORT}?`, true);
+        reconnectBtn.style.display = "inline-block";
+      };
+
+      term.onData((data) => send(data));
+    }
+
+    // ── on-screen button wiring ───────────────────────────────────────────
+    // Use touchstart so response is instant (no 300 ms tap delay).
+    // preventDefault stops the browser also firing a click and doubling input.
+    document.querySelectorAll(".ctrl-btn").forEach((btn) => {
+      const key = btn.dataset.key;
+      const seq = KEY_SEQUENCES[key];
+      if (!seq) return;
+
+      // touchstart for fast response on mobile
+      btn.addEventListener("touchstart", (e) => {
+        e.preventDefault();
+        send(seq);
+      }, { passive: false });
+
+      // mousedown so desktop users can also click the buttons
+      btn.addEventListener("mousedown", (e) => {
+        e.preventDefault();
+        send(seq);
+      });
+    });
+
+    connect();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds a `--web` flag that launches Roam in a browser via a local HTTP + WebSocket server
- Replaces the original xterm.js terminal approach with a native HTML5 canvas renderer that receives JSON draw-call batches from the server
- Full input support: keyboard, mouse click/hover, touch tap, and drag gestures (for HUD repositioning on mobile)

## What's included

- `WebRenderer` — captures all draw calls (tiles, text, buttons, overlays, clip regions) as JSON and sends batched frames over WebSocket; suppresses duplicate frames
- `WebInputSource` — queues keyboard, mouse, and resize events from the browser back into the game loop
- `WebFrontend` — HTTP server serves `web/index.html` and `/assets/...` directly from the project root so tile sprites load without copying
- `web/index.html` — self-contained, no external dependencies; scales to any screen size, handles devicePixelRatio for sharp retina rendering
- UX polish: button auto-size font, rounded corners, hover highlight, tap ripple feedback, status bar auto-collapse, dark/light border contrast, drag-to-reposition HUD elements

## Test plan

- [ ] `python3 roam.py --web` launches and opens in browser
- [ ] Keyboard input moves player
- [ ] Mouse click / touch tap interacts with world and menu buttons
- [ ] HUD elements can be dragged on both desktop and mobile
- [ ] Tile sprites load (no permanent placeholders)
- [ ] Reconnect button appears on disconnect, hides on reconnect
- [ ] `python3 -m pytest tests/ -q` passes
- [ ] `python3 -m black --check src tests` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_