### PR TITLE
fix: web mode — skip save selection, start world directly

### DIFF
--- a/src/rendering/webFrontend.py
+++ b/src/rendering/webFrontend.py
@@ -220,7 +220,7 @@ def _startHttpServer(port, wsPort):
                 from urllib.parse import unquote, urlparse
 
                 path = unquote(urlparse(self.path).path)
-                if path in ("/", "/index.html"):
+                if path in ("/", "/index.html", "/play", "/play/"):
                     # Ensure each browser has a persistent session cookie so
                     # its save files survive page reloads and reconnects.
                     existing = _parseSessionId(dict(self.headers))

--- a/src/roam.py
+++ b/src/roam.py
@@ -278,6 +278,10 @@ def main(argv):
                     "defaultsavefile",
                 )
             roam = Roam(sessionConfig, frontend=session)
+            # Web sessions have a fixed per-session save path — skip the main
+            # menu's save selection screen and go straight to the world.
+            roam.initializeWorldScreen()
+            roam.currentScreen = roam.worldScreen
             try:
                 while True:
                     result = roam.run()


### PR DESCRIPTION
## Problem

Web sessions have a fixed per-session save path (UUID cookie). The main menu routed "Play" to `SaveSelectionScreen`, which scans `getSavesBaseDirectory()` — showing every other session's UUID directory as a selectable "save". Players saw a list of UUID-named saves and could accidentally load another session's world.

## Fix

After creating the `Roam` instance in `_sessionGameLoop`, immediately call `initializeWorldScreen()` and set `currentScreen = worldScreen`. Web players land directly in their own session's world with no save picker shown.

Also includes the earlier `/play` path fix (serve index.html for `/play` and `/play/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_