### PR TITLE
fix: extract Dockerfile inline Python to web/build_zip.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,25 +7,7 @@ COPY . .
 # Build the Python game bundle downloaded by the browser's Pyodide Worker.
 # game.zip contains all source code + schemas + config; assets are served
 # separately over HTTP (they're large and already in the image via COPY).
-RUN python3 -c "
-import zipfile, os
-
-with zipfile.ZipFile('web/game.zip', 'w', zipfile.ZIP_DEFLATED) as z:
-    for root, dirs, files in os.walk('src'):
-        dirs[:] = [d for d in dirs if d != '__pycache__']
-        for f in files:
-            if not f.endswith('.pyc'):
-                path = os.path.join(root, f)
-                z.write(path, path)
-    for root, dirs, files in os.walk('schemas'):
-        dirs[:] = [d for d in dirs if d != '__pycache__']
-        for f in files:
-            z.write(os.path.join(root, f), os.path.join(root, f))
-    for name in ('config.yml', 'version.txt'):
-        if os.path.exists(name):
-            z.write(name, name)
-print('Built web/game.zip')
-"
+RUN python3 web/build_zip.py
 
 EXPOSE 8080
 

--- a/web/build_zip.py
+++ b/web/build_zip.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Build web/game.zip — run at Docker build time via Dockerfile RUN step.
+
+Bundles the Python source tree, schemas, and config into a single zip that
+the browser's Pyodide Worker downloads and unpacks into its virtual filesystem.
+"""
+import os
+import zipfile
+
+with zipfile.ZipFile("web/game.zip", "w", zipfile.ZIP_DEFLATED) as z:
+    for root, dirs, files in os.walk("src"):
+        dirs[:] = [d for d in dirs if d != "__pycache__"]
+        for f in files:
+            if not f.endswith(".pyc"):
+                path = os.path.join(root, f)
+                z.write(path, path)
+    for root, dirs, files in os.walk("schemas"):
+        dirs[:] = [d for d in dirs if d != "__pycache__"]
+        for f in files:
+            z.write(os.path.join(root, f), os.path.join(root, f))
+    for name in ("config.yml", "version.txt"):
+        if os.path.exists(name):
+            z.write(name, name)
+
+print("Built web/game.zip")


### PR DESCRIPTION
Docker parses multi-line `RUN python3 -c "..."` strings as Dockerfile instructions, treating `import` as an unknown instruction. This caused the deploy to fail with `dockerfile parse error on line 11: unknown instruction: import`.

Fix: move the zip-building logic to `web/build_zip.py` and call `RUN python3 web/build_zip.py`.

Closes: gateway deploy failure from PR #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_