### PR TITLE
fix: include web/pyodide_main.py in game.zip bundle

### DIFF
--- a/web/build_zip.py
+++ b/web/build_zip.py
@@ -21,5 +21,8 @@ with zipfile.ZipFile("web/game.zip", "w", zipfile.ZIP_DEFLATED) as z:
     for name in ("config.yml", "version.txt"):
         if os.path.exists(name):
             z.write(name, name)
+    # Entry point run by the Web Worker after unpacking to /game/
+    if os.path.exists("web/pyodide_main.py"):
+        z.write("web/pyodide_main.py", "web/pyodide_main.py")
 
 print("Built web/game.zip")


### PR DESCRIPTION
The Web Worker unpacks `game.zip` to `/game/` and then execs `/game/web/pyodide_main.py`, but the file was missing from the zip — only `src/`, `schemas/`, and `config.yml` were included.

Add `web/pyodide_main.py` to `build_zip.py` so it lands at `/game/web/pyodide_main.py` after unpacking.

Fixes: `FileNotFoundError: no such file or directory /game/web/pyodide_main.py` at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_