### PR TITLE
fix: install structlog, Pillow, jsonschema in Pyodide Worker

### DIFF
--- a/web/game-worker.js
+++ b/web/game-worker.js
@@ -50,6 +50,14 @@ self.onmessage = async (e) => {
             console.warn('[roam] OPFS unavailable; saves will not persist across reloads');
         }
 
+        self.postMessage({ type: 'status', msg: 'Installing Python packages…' });
+
+        // Pillow and jsonschema are bundled with Pyodide; structlog comes from PyPI.
+        // micropip handles PyPI installs and skips packages already available.
+        await pyodide.loadPackage(['Pillow', 'jsonschema', 'micropip']);
+        const micropip = pyodide.pyimport('micropip');
+        await micropip.install('structlog');
+
         self.postMessage({ type: 'status', msg: 'Downloading game…' });
 
         const resp = await fetch('/web/game.zip');


### PR DESCRIPTION
These packages are imported at module level during game startup and aren't available in Pyodide by default:

- **structlog** — `gameLogging/logger.py` imports and configures it at module load time; every other module that calls `getLogger()` fails if it's missing
- **PIL/Pillow** — `worldScreen` → `MapImageUpdater` → `MapImageGenerator` import chain; Pillow is bundled in Pyodide v0.26 so no PyPI fetch needed
- **jsonschema** — used by world persistence, codex, inventory; also bundled in Pyodide v0.26

Adds an "Installing Python packages…" status step in the Worker between OPFS mount and game download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_