### PR TITLE
fix: sync executor + selectable error text for Pyodide

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -40,6 +40,7 @@
       border-bottom-width: 0;
     }
     #bar-status { flex: 1; color: #666; }
+    #bar-status.error { color: #c55; user-select: text; -webkit-user-select: text; cursor: text; }
     #bar-reconnect {
       display: none;
       background: #1e1e1e;
@@ -452,7 +453,7 @@
 
   function setStatus(msg, isError) {
     statusEl.textContent = msg;
-    statusEl.style.color = isError ? "#c55" : "#666";
+    statusEl.classList.toggle('error', !!isError);
   }
 
   function startWorker() {

--- a/web/pyodide_main.py
+++ b/web/pyodide_main.py
@@ -9,8 +9,10 @@ This file is exec()'d by pyodide.runPythonAsync() and shares that namespace,
 so all js module globals are reachable via `from js import ...`.
 """
 
+import concurrent.futures as _cf
 import json
 import queue
+import threading as _threading
 
 import js as _js
 from js import Atomics, sabData, sabMeta, sabRingSize, sendToMain
@@ -25,6 +27,60 @@ def _post(obj):
         sendToMain(_to_js(obj, dict_converter=_js.Object.fromEntries))
 
 
+# ── Pyodide thread compatibility ──────────────────────────────────────────────
+# Pyodide's CDN WASM build cannot spawn OS threads.  Patch both
+# concurrent.futures and threading BEFORE game modules import them so all
+# ThreadPoolExecutor usage runs tasks synchronously rather than crashing, and
+# daemon thread starts (e.g. UpdateChecker) are silently dropped.
+
+
+class _PyodideFuture:
+    _result = None
+    _exc = None
+
+    def result(self, timeout=None):
+        if self._exc is not None:
+            raise self._exc
+        return self._result
+
+
+class _PyodideExecutor:
+    """Synchronous stand-in for ThreadPoolExecutor on Pyodide."""
+
+    def submit(self, fn, /, *args, **kwargs):
+        f = _PyodideFuture()
+        try:
+            f._result = fn(*args, **kwargs)
+        except Exception as e:
+            f._exc = e
+        return f
+
+    def shutdown(self, wait=True, cancel_futures=False):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        self.shutdown()
+
+
+_cf.ThreadPoolExecutor = _PyodideExecutor
+
+_orig_thread_start = _threading.Thread.start
+
+
+def _safe_thread_start(self):
+    try:
+        _orig_thread_start(self)
+    except RuntimeError:
+        if not self.daemon:
+            raise  # non-daemon failure is unexpected; let it propagate
+
+
+_threading.Thread.start = _safe_thread_start
+
+# ── game imports (must come after the patches above) ─────────────────────────
 from config.config import Config
 from rendering.textClock import TextClock
 from rendering.webInputSource import WebInputSource


### PR DESCRIPTION
### Threading
Pyodide's CDN WASM build cannot spawn OS threads. `UpdateChecker.checkForUpdatesAsync()` raises `RuntimeError: can't start new thread` on the main menu. `WorldScreen._saveExecutor` and `MapImageUpdater._executor` would hit the same error later.

**Fix:** patch `concurrent.futures.ThreadPoolExecutor` in the module namespace before game modules import it, replacing it with `_PyodideExecutor` which runs tasks synchronously. Also patch `threading.Thread.start` to silently drop daemon thread failures (belt+suspenders for any direct `threading.Thread` usage).

Saves still happen — they just run inline on the game loop thread rather than in a background pool.

### Error copy
`body { user-select: none }` blocked selection of error text in the status bar. Add `.error` CSS class that re-enables `user-select: text` so error messages can be copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_