### PR TITLE
fix: guard thread.start() in UpdateChecker; add Pyodide regression test

### DIFF
--- a/src/update/updateChecker.py
+++ b/src/update/updateChecker.py
@@ -43,8 +43,11 @@ class UpdateChecker:
         if self._checkStarted or not self.config.checkForUpdates:
             return
         self._checkStarted = True
-        thread = threading.Thread(target=self._checkForUpdates, daemon=True)
-        thread.start()
+        try:
+            thread = threading.Thread(target=self._checkForUpdates, daemon=True)
+            thread.start()
+        except RuntimeError:
+            self._checkStarted = False
 
     def _checkForUpdates(self):
         latest = self._fetchLatestVersion()

--- a/tests/update/test_updateChecker.py
+++ b/tests/update/test_updateChecker.py
@@ -124,3 +124,14 @@ def test_async_check_is_noop_when_disabled():
     checker.checkForUpdatesAsync()
     assert checker._checkStarted is False
     assert checker.isUpdateAvailable() is False
+
+
+def test_async_check_survives_runtime_error_on_thread_start():
+    # Pyodide/WASM can't spawn threads; thread.start() raises RuntimeError.
+    # checkForUpdatesAsync must not propagate the error so the main menu loads.
+    checker = _checker()
+    with patch(
+        "threading.Thread.start", side_effect=RuntimeError("can't start new thread")
+    ):
+        checker.checkForUpdatesAsync()
+    assert checker.isUpdateAvailable() is False

--- a/web/pyodide_main.py
+++ b/web/pyodide_main.py
@@ -12,7 +12,6 @@ so all js module globals are reachable via `from js import ...`.
 import concurrent.futures as _cf
 import json
 import queue
-import threading as _threading
 
 import js as _js
 from js import Atomics, sabData, sabMeta, sabRingSize, sendToMain
@@ -66,19 +65,6 @@ class _PyodideExecutor:
 
 
 _cf.ThreadPoolExecutor = _PyodideExecutor
-
-_orig_thread_start = _threading.Thread.start
-
-
-def _safe_thread_start(self):
-    try:
-        _orig_thread_start(self)
-    except RuntimeError:
-        if not self.daemon:
-            raise  # non-daemon failure is unexpected; let it propagate
-
-
-_threading.Thread.start = _safe_thread_start
 
 # ── game imports (must come after the patches above) ─────────────────────────
 from config.config import Config


### PR DESCRIPTION
`updateChecker.checkForUpdatesAsync()` calls `thread.start()` which raises `RuntimeError: can't start new thread` in Pyodide/WASM. Wrapping it in `try/except RuntimeError` lets the main menu load normally.

The `Thread.start` monkey-patch added in the previous commit didn't work — Pyodide's frozen `threading.py` bypasses class-level attribute assignment. Removed it; the `_PyodideExecutor` ThreadPoolExecutor patch stays (it does work).

**Regression test:** `test_async_check_survives_runtime_error_on_thread_start` patches `Thread.start` to raise `RuntimeError` and asserts the game doesn't crash — this exact scenario will now be caught by CI before it reaches prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_