### PR TITLE
fix: add __init__ to _PyodideExecutor to accept constructor args

### DIFF
--- a/web/pyodide_main.py
+++ b/web/pyodide_main.py
@@ -46,6 +46,9 @@ class _PyodideFuture:
 class _PyodideExecutor:
     """Synchronous stand-in for ThreadPoolExecutor on Pyodide."""
 
+    def __init__(self, *args, **kwargs):
+        pass
+
     def submit(self, fn, /, *args, **kwargs):
         f = _PyodideFuture()
         try:


### PR DESCRIPTION
`ThreadPoolExecutor(max_workers=N)` is called with keyword arguments in `roomPreloader`, `mapImageUpdater`, and `worldScreen`. `_PyodideExecutor` had no `__init__`, so all three raised `TypeError: _PyodideExecutor() takes no arguments` at game startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_