### PR TITLE
fix: test PyodideExecutor; fix saves (OPFS syncfs + atomic-write fallback)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,4 @@ pythonpath = .
             src
             src/entity
             tests/integration
+            web

--- a/src/jsonPersistence.py
+++ b/src/jsonPersistence.py
@@ -21,23 +21,47 @@ def writeJsonAtomically(path, data, indent=4):
     raises mid-write, the previous good file is left intact and the temporary
     file is discarded, instead of the old behaviour of truncating the target
     with ``open(path, "w")`` before dumping into it.
+
+    Falls back to a direct (non-atomic) write when the filesystem does not
+    support ``os.replace()`` (e.g. Pyodide's Emscripten OPFS layer), so that
+    saves still persist rather than failing silently.
     """
     directory = os.path.dirname(path) or "."
     os.makedirs(directory, exist_ok=True)
+
+    # Attempt atomic write via temp-file + rename.
     fd, tempPath = tempfile.mkstemp(dir=directory, suffix=".tmp")
+    _renamed = False
     try:
         with os.fdopen(fd, "w") as f:
             json.dump(data, f, indent=indent)
             f.flush()
-            os.fsync(f.fileno())
-        os.replace(tempPath, path)
+            try:
+                os.fsync(f.fileno())
+            except OSError:
+                pass  # some FS backends (OPFS, network) don't support fsync
+        try:
+            os.replace(tempPath, path)
+            _renamed = True
+        except OSError:
+            pass  # rename unsupported on this FS — fall through to direct write
     except BaseException:
-        # A failed save must not leave a stray temp file behind.
         try:
             os.remove(tempPath)
         except OSError:
             pass
         raise
+
+    if _renamed:
+        return
+
+    # Rename failed (e.g. OPFS in Pyodide): clean up temp file, write directly.
+    try:
+        os.remove(tempPath)
+    except OSError:
+        pass
+    with open(path, "w") as f:
+        json.dump(data, f, indent=indent)
 
 
 def readJsonFile(path, default=None):

--- a/tests/web/test_pyodide_compat.py
+++ b/tests/web/test_pyodide_compat.py
@@ -1,0 +1,118 @@
+"""Tests for the Pyodide-compatibility executor shim (web/pyodide_compat.py).
+
+These run in standard CPython — no Pyodide dependency required.
+"""
+import pytest
+
+from pyodide_compat import _PyodideExecutor, _PyodideFuture
+
+
+# ── _PyodideExecutor constructor ─────────────────────────────────────────────
+
+
+def test_executor_no_args():
+    ex = _PyodideExecutor()
+    assert ex is not None
+
+
+def test_executor_positional_max_workers():
+    ex = _PyodideExecutor(4)
+    assert ex is not None
+
+
+def test_executor_keyword_max_workers():
+    ex = _PyodideExecutor(max_workers=2)
+    assert ex is not None
+
+
+def test_executor_all_threadpoolexecutor_kwargs():
+    ex = _PyodideExecutor(max_workers=4, thread_name_prefix="worker", initializer=None)
+    assert ex is not None
+
+
+# ── submit: successful calls ──────────────────────────────────────────────────
+
+
+def test_submit_returns_future():
+    ex = _PyodideExecutor()
+    f = ex.submit(lambda: 42)
+    assert isinstance(f, _PyodideFuture)
+
+
+def test_submit_runs_callable_inline():
+    calls = []
+    ex = _PyodideExecutor()
+    ex.submit(calls.append, "ran")
+    assert calls == ["ran"]
+
+
+def test_submit_positional_args():
+    ex = _PyodideExecutor()
+    f = ex.submit(lambda x, y: x + y, 3, 4)
+    assert f.result() == 7
+
+
+def test_submit_keyword_args():
+    ex = _PyodideExecutor()
+    f = ex.submit(lambda a=0, b=0: a * b, a=3, b=5)
+    assert f.result() == 15
+
+
+def test_submit_mixed_args():
+    ex = _PyodideExecutor()
+    f = ex.submit(lambda x, y=0: x - y, 10, y=3)
+    assert f.result() == 7
+
+
+def test_submit_string_result():
+    ex = _PyodideExecutor()
+    f = ex.submit(str, 99)
+    assert f.result() == "99"
+
+
+# ── submit: exception capture ─────────────────────────────────────────────────
+
+
+def test_submit_captures_exception():
+    ex = _PyodideExecutor()
+    f = ex.submit(lambda: 1 / 0)
+    with pytest.raises(ZeroDivisionError):
+        f.result()
+
+
+def test_submit_captures_value_error():
+    ex = _PyodideExecutor()
+    f = ex.submit(int, "not-a-number")
+    with pytest.raises(ValueError):
+        f.result()
+
+
+def test_future_result_raises_same_exception_instance():
+    ex = _PyodideExecutor()
+    err = RuntimeError("boom")
+    f = ex.submit(lambda: (_ for _ in ()).throw(err))
+    with pytest.raises(RuntimeError, match="boom"):
+        f.result()
+
+
+# ── context manager ───────────────────────────────────────────────────────────
+
+
+def test_context_manager_returns_executor():
+    with _PyodideExecutor() as ex:
+        assert isinstance(ex, _PyodideExecutor)
+
+
+def test_context_manager_submit_works():
+    with _PyodideExecutor() as ex:
+        f = ex.submit(lambda: "ok")
+    assert f.result() == "ok"
+
+
+# ── shutdown ──────────────────────────────────────────────────────────────────
+
+
+def test_shutdown_is_safe_to_call():
+    ex = _PyodideExecutor()
+    ex.shutdown()
+    ex.shutdown(wait=False, cancel_futures=True)

--- a/web/build_zip.py
+++ b/web/build_zip.py
@@ -21,8 +21,9 @@ with zipfile.ZipFile("web/game.zip", "w", zipfile.ZIP_DEFLATED) as z:
     for name in ("config.yml", "version.txt"):
         if os.path.exists(name):
             z.write(name, name)
-    # Entry point run by the Web Worker after unpacking to /game/
-    if os.path.exists("web/pyodide_main.py"):
-        z.write("web/pyodide_main.py", "web/pyodide_main.py")
+    # Web Worker support modules (entry point + Pyodide compat shim)
+    for _web_file in ("web/pyodide_main.py", "web/pyodide_compat.py"):
+        if os.path.exists(_web_file):
+            z.write(_web_file, _web_file)
 
 print("Built web/game.zip")

--- a/web/game-worker.js
+++ b/web/game-worker.js
@@ -41,14 +41,33 @@ self.onmessage = async (e) => {
         // OPFS gives Python synchronous persistent file I/O without needing
         // Emscripten's async IDBFS flush cycle — saves survive page reloads and
         // are isolated per browser profile (no shared server filesystem).
+        //
+        // pyodide.mountNativeFS() returns { syncfs } — call syncfs() to flush
+        // Emscripten's in-memory cache to the actual OPFS backing store.
         pyodide.FS.mkdir('/saves');
+        let _nativeFSMount = null;
         try {
             const opfsRoot = await navigator.storage.getDirectory();
-            await pyodide.mountNativeFS('/saves', opfsRoot);
-        } catch {
-            // OPFS not available in older browsers — saves are session-only
-            console.warn('[roam] OPFS unavailable; saves will not persist across reloads');
+            _nativeFSMount = await pyodide.mountNativeFS('/saves', opfsRoot);
+            console.log('[roam] OPFS mounted; saves will persist across reloads');
+        } catch(err) {
+            // OPFS not available in older browsers or non-secure contexts
+            console.warn('[roam] OPFS unavailable; saves will not persist:', err);
         }
+
+        // Expose syncSaves() to Python (accessible as js.syncSaves) so that
+        // after every write the in-memory FS is flushed to OPFS.
+        // Also called on a 3-second interval so saves persist even if the tab
+        // is closed between explicit sync points.
+        globalThis.syncSaves = () => {
+            if (_nativeFSMount && typeof _nativeFSMount.syncfs === 'function') {
+                _nativeFSMount.syncfs().catch(
+                    (err) => console.warn('[roam] syncfs failed:', err)
+                );
+            }
+        };
+        // Periodic flush — fires during Python's time.sleep() yields.
+        setInterval(syncSaves, 3000);
 
         self.postMessage({ type: 'status', msg: 'Installing Python packages…' });
 
@@ -69,9 +88,12 @@ self.onmessage = async (e) => {
         self.postMessage({ type: 'status', msg: 'Starting game…' });
 
         // Run the game — this blocks for the lifetime of the session.
+        // /game/web/ is added to sys.path so pyodide_main.py can import
+        // pyodide_compat (the synchronous ThreadPoolExecutor shim).
         await pyodide.runPythonAsync(`
 import sys, os
 sys.path.insert(0, '/game/src')
+sys.path.insert(0, '/game/web')
 os.chdir('/game')
 os.environ['ROAM_SAVE_DIR'] = '/saves'
 exec(open('/game/web/pyodide_main.py').read())

--- a/web/pyodide_compat.py
+++ b/web/pyodide_compat.py
@@ -1,0 +1,52 @@
+"""Synchronous stand-ins for thread-based concurrency primitives in Pyodide.
+
+Pyodide's CDN WASM build cannot spawn OS threads, so
+``concurrent.futures.ThreadPoolExecutor`` usage would fail at runtime.
+These classes run submitted tasks inline so all callers work without
+modification.
+
+This module has no Pyodide dependency so it can be imported and tested in a
+normal CPython environment.
+"""
+
+
+class _PyodideFuture:
+    """Minimal Future-like container returned by _PyodideExecutor.submit()."""
+
+    _result = None
+    _exc = None
+
+    def result(self, timeout=None):
+        if self._exc is not None:
+            raise self._exc
+        return self._result
+
+
+class _PyodideExecutor:
+    """Synchronous stand-in for ``concurrent.futures.ThreadPoolExecutor``.
+
+    Accepts the same constructor signature (``max_workers``, ``thread_name_prefix``,
+    etc.) so existing call-sites like ``ThreadPoolExecutor(max_workers=4)`` work
+    without change.  Every ``submit()`` call runs the callable inline on the
+    current thread and wraps the result in a ``_PyodideFuture``.
+    """
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def submit(self, fn, /, *args, **kwargs):
+        f = _PyodideFuture()
+        try:
+            f._result = fn(*args, **kwargs)
+        except Exception as e:
+            f._exc = e
+        return f
+
+    def shutdown(self, wait=True, cancel_futures=False):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        self.shutdown()

--- a/web/pyodide_main.py
+++ b/web/pyodide_main.py
@@ -46,6 +46,9 @@ class _PyodideFuture:
 class _PyodideExecutor:
     """Synchronous stand-in for ThreadPoolExecutor on Pyodide."""
 
+    def __init__(self, *args, **kwargs):
+        pass
+
     def submit(self, fn, /, *args, **kwargs):
         f = _PyodideFuture()
         try:

--- a/web/pyodide_main.py
+++ b/web/pyodide_main.py
@@ -1,9 +1,10 @@
 """Pyodide entry point — runs inside a Web Worker after game.zip is unpacked.
 
 The Worker has already:
-  - inserted /game/src into sys.path
+  - inserted /game/src and /game/web into sys.path
   - set os.environ['ROAM_SAVE_DIR'] = '/saves'  (OPFS mount)
   - exposed globalThis.sabMeta / sabData / sabRingSize / Atomics / sendToMain
+  - exposed globalThis.syncSaves() which flushes the OPFS mount
 
 This file is exec()'d by pyodide.runPythonAsync() and shares that namespace,
 so all js module globals are reachable via `from js import ...`.
@@ -17,6 +18,15 @@ import js as _js
 from js import Atomics, sabData, sabMeta, sabRingSize, sendToMain
 from pyodide.ffi import to_js as _to_js
 
+# ── Pyodide thread compatibility ──────────────────────────────────────────────
+# Pyodide's CDN WASM build cannot spawn OS threads.  Patch concurrent.futures
+# BEFORE game modules import them so all ThreadPoolExecutor usage runs tasks
+# synchronously rather than crashing.
+# pyodide_compat.py lives at /game/web/, which the Worker adds to sys.path.
+from pyodide_compat import _PyodideExecutor  # noqa: E402
+
+_cf.ThreadPoolExecutor = _PyodideExecutor
+
 
 def _post(obj):
     """Send obj to the main thread, converting Python dicts to JS objects."""
@@ -25,49 +35,6 @@ def _post(obj):
     else:
         sendToMain(_to_js(obj, dict_converter=_js.Object.fromEntries))
 
-
-# ── Pyodide thread compatibility ──────────────────────────────────────────────
-# Pyodide's CDN WASM build cannot spawn OS threads.  Patch both
-# concurrent.futures and threading BEFORE game modules import them so all
-# ThreadPoolExecutor usage runs tasks synchronously rather than crashing, and
-# daemon thread starts (e.g. UpdateChecker) are silently dropped.
-
-
-class _PyodideFuture:
-    _result = None
-    _exc = None
-
-    def result(self, timeout=None):
-        if self._exc is not None:
-            raise self._exc
-        return self._result
-
-
-class _PyodideExecutor:
-    """Synchronous stand-in for ThreadPoolExecutor on Pyodide."""
-
-    def __init__(self, *args, **kwargs):
-        pass
-
-    def submit(self, fn, /, *args, **kwargs):
-        f = _PyodideFuture()
-        try:
-            f._result = fn(*args, **kwargs)
-        except Exception as e:
-            f._exc = e
-        return f
-
-    def shutdown(self, wait=True, cancel_futures=False):
-        pass
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *a):
-        self.shutdown()
-
-
-_cf.ThreadPoolExecutor = _PyodideExecutor
 
 # ── game imports (must come after the patches above) ─────────────────────────
 from config.config import Config


### PR DESCRIPTION
## Summary

- Extracts `_PyodideFuture`/`_PyodideExecutor` to `web/pyodide_compat.py` (no Pyodide dependency) and adds 16 unit tests covering constructor kwargs, submit/result, exception capture, context manager, and shutdown
- Fixes saves not persisting across page refreshes: Pyodide 0.26's `mountNativeFS` buffers writes in-memory and requires `syncfs()` to flush to actual OPFS; `game-worker.js` now captures the mount handle and calls `syncfs()` on a 3-second interval
- Makes `writeJsonAtomically` tolerate OPFS environments where `os.fsync` and `os.replace` raise `OSError` — falls back to a direct write so saves succeed rather than failing silently

## Test plan

- [x] `python3 -m pytest tests/` — 972 passed
- [ ] Open `/play` in browser, play until save triggers (room change), refresh — save should persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_