### PR TITLE
fix: move IDB writes to main thread — saves persist across reload

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,57 @@
+name: Integration tests
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+permissions:
+  contents: read
+
+jobs:
+  save-persistence:
+    name: Save persistence (Playwright)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pygame pytest jsonschema Pillow structlog
+
+      - name: Build game.zip
+        run: python3 web/build_zip.py
+
+      - name: Install Node + Playwright
+        run: |
+          npm install -g playwright
+          npx playwright install chromium
+          npx playwright install-deps chromium
+
+      - name: Start local game server
+        run: |
+          python3 web/serve.py &
+          echo "SERVER_PID=$!" >> $GITHUB_ENV
+          # Wait until the server is accepting connections
+          for i in $(seq 1 20); do
+            curl -sf http://localhost:8080/ > /dev/null && break
+            sleep 1
+          done
+
+      - name: Run save-persistence integration test
+        env:
+          ROAM_URL: http://localhost:8080
+          NODE_PATH: /usr/local/lib/node_modules
+        run: node tests/integration/test_save_persistence.js
+
+      - name: Stop game server
+        if: always()
+        run: kill "$SERVER_PID" 2>/dev/null || true

--- a/tests/integration/test_save_persistence.js
+++ b/tests/integration/test_save_persistence.js
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+// Integration test: verifies save files written during gameplay persist across
+// a page reload via IndexedDB.
+//
+// Usage:
+//   node tests/integration/test_save_persistence.js [URL]
+//
+// Defaults to http://localhost:8080.  Pass the live URL to test production:
+//   ROAM_URL=https://roam.preponderous.org node tests/integration/test_save_persistence.js
+//
+// Exit code: 0 = pass, 1 = fail.
+// Requires: npm install -g playwright && npx playwright install chromium
+
+"use strict";
+
+const { chromium } = require("playwright");
+
+const BASE = process.env.ROAM_URL || process.argv[2] || "http://localhost:8080";
+
+async function readIDB(page) {
+    return page.evaluate(() => new Promise((resolve) => {
+        const req = indexedDB.open("roam-saves", 1);
+        req.onerror = () => resolve({});
+        req.onsuccess = (e) => {
+            const db = e.target.result;
+            if (!db.objectStoreNames.contains("files")) { db.close(); resolve({}); return; }
+            const result = {};
+            const tx = db.transaction("files", "readonly");
+            const cursor = tx.objectStore("files").openCursor();
+            cursor.onsuccess = (ev) => {
+                const c = ev.target.result;
+                if (c) { result[c.key] = String(c.value).length; c.continue(); }
+                else   { db.close(); resolve(result); }
+            };
+            cursor.onerror = () => { db.close(); resolve(result); };
+        };
+    })).catch(() => ({}));
+}
+
+async function waitForStatus(page, target, maxMs = 120000) {
+    const deadline = Date.now() + maxMs;
+    let last = "";
+    while (Date.now() < deadline) {
+        const s = await page.evaluate(() => {
+            const el = document.getElementById("bar-status");
+            return el ? el.textContent.trim() : "";
+        }).catch(() => "");
+        if (s !== last) { process.stderr.write(`  [status] ${s}\n`); last = s; }
+        if (s === target) return true;
+        const err = await page.evaluate(() => {
+            const el = document.getElementById("error");
+            return (el && el.style.display !== "none") ? el.textContent.trim() : "";
+        }).catch(() => "");
+        if (err) { process.stderr.write(`  [error] ${err}\n`); return false; }
+        await page.waitForTimeout(500);
+    }
+    process.stderr.write(`  [timeout] never reached status "${target}"\n`);
+    return false;
+}
+
+async function pressKey(page, key, times = 1, delay = 400) {
+    for (let i = 0; i < times; i++) {
+        await page.keyboard.press(key);
+        await page.waitForTimeout(delay);
+    }
+}
+
+(async () => {
+    process.stderr.write(`\n=== Roam save-persistence integration test ===\n`);
+    process.stderr.write(`Target: ${BASE}\n\n`);
+
+    const browser = await chromium.launch({ headless: true });
+    const ctx = await browser.newContext({
+        viewport: { width: 412, height: 915 },
+        userAgent: "Mozilla/5.0 (Linux; Android 12; Pixel 6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Mobile Safari/537.36",
+    });
+    const page = await ctx.newPage();
+
+    page.on("console", msg => {
+        const t = msg.type() === "error" ? "ERR" : msg.type() === "warning" ? "WARN" : "LOG";
+        process.stderr.write(`  [browser:${t}] ${msg.text()}\n`);
+    });
+    page.on("pageerror", e => process.stderr.write(`  [pageerror] ${e.message}\n`));
+
+    // ── Load #1 ────────────────────────────────────────────────────────────────
+    process.stderr.write("--- Load\n");
+    await page.goto(`${BASE}/play`, { waitUntil: "domcontentloaded", timeout: 30000 });
+    if (!await waitForStatus(page, "Starting game…", 120000)) {
+        process.stderr.write("FAIL: game did not reach Starting game…\n");
+        await browser.close(); process.exit(1);
+    }
+    await page.waitForTimeout(2000);
+
+    // ── Navigate into world (title → save select → world) ─────────────────────
+    process.stderr.write("--- Navigating into world\n");
+    await pressKey(page, "Enter", 3, 600);
+    await pressKey(page, "ArrowDown", 1, 400);
+    await pressKey(page, "Enter", 3, 800);
+    await page.waitForTimeout(2000);
+
+    // ── Poll IDB until files appear ────────────────────────────────────────────
+    process.stderr.write("--- Polling IndexedDB\n");
+    let idb1 = {};
+    for (let i = 0; i < 30; i++) {
+        await page.waitForTimeout(1000);
+        idb1 = await readIDB(page);
+        if (Object.keys(idb1).length > 0) {
+            process.stderr.write(`  files appeared after ${i+1}s\n`);
+            break;
+        }
+    }
+
+    if (Object.keys(idb1).length === 0) {
+        process.stderr.write("FAIL: no save files reached IndexedDB after 30s of gameplay\n");
+        await browser.close(); process.exit(1);
+    }
+
+    process.stderr.write(`\n[IDB before reload — ${Object.keys(idb1).length} file(s)]\n`);
+    for (const [k, v] of Object.entries(idb1)) process.stderr.write(`  ${k} (${v} chars)\n`);
+
+    // ── Reload ─────────────────────────────────────────────────────────────────
+    process.stderr.write("\n--- Reload\n");
+    await page.reload({ waitUntil: "domcontentloaded", timeout: 30000 });
+    if (!await waitForStatus(page, "Starting game…", 120000)) {
+        process.stderr.write("FAIL: game did not restart after reload\n");
+        await browser.close(); process.exit(1);
+    }
+    await page.waitForTimeout(2000);
+
+    const idb2 = await readIDB(page);
+    process.stderr.write(`\n[IDB after reload — ${Object.keys(idb2).length} file(s)]\n`);
+    for (const [k, v] of Object.entries(idb2)) process.stderr.write(`  ${k} (${v} chars)\n`);
+
+    // ── Verdict ────────────────────────────────────────────────────────────────
+    process.stderr.write("\n--- Verdict\n");
+    const k1 = Object.keys(idb1).sort();
+    const k2 = Object.keys(idb2).sort();
+    const allRestored = k1.every(k => k2.includes(k));
+
+    if (allRestored && k2.length >= k1.length) {
+        process.stderr.write(`PASS: ${k1.length} save file(s) persisted and restored across reload\n`);
+        k1.forEach(k => process.stderr.write(`  ${k}\n`));
+        await browser.close();
+        process.exit(0);
+    } else {
+        process.stderr.write(`FAIL: before [${k1.join(", ")}] vs after [${k2.join(", ")}]\n`);
+        await browser.close();
+        process.exit(1);
+    }
+})();

--- a/web/game-worker.js
+++ b/web/game-worker.js
@@ -6,27 +6,153 @@
 //                   { type: 'status', msg: string }
 //                   { type: 'ready' }
 //                   { type: 'error', msg: string }
+//                   { type: 'save', files: { path: content, ... } }
 //
 // Input arrives via the SharedArrayBuffer ring buffer (main thread writes,
 // Python reads) so key/mouse events reach the game loop without depending on
 // Worker onmessage, which cannot fire while Python is blocking.
+//
+// ── Why IDB writes live on the main thread ───────────────────────────────────
+// Pyodide's CDN build uses Atomics.wait() for time.sleep() when SharedArrayBuffer
+// is available. Atomics.wait blocks the Worker's JS event loop entirely, so IDB
+// callbacks (macrotasks) can never fire while Python is running. Solution: the
+// Worker walks /saves synchronously and postMessages the file map to the main
+// thread; the main thread writes to IDB from its own (unblocked) event loop.
+// The initial save restore still runs in the Worker because it happens before
+// Python starts (no Atomics.wait yet), so IDB callbacks fire normally there.
 
 importScripts('https://cdn.jsdelivr.net/pyodide/v0.26.0/full/pyodide.js');
 
 const SAB_RING_SIZE = 8192;
 
+// ── Save restore: Worker reads IDB on startup (before Python blocks) ──────────
+
+const IDB_NAME    = 'roam-saves';
+const IDB_STORE   = 'files';
+const IDB_VERSION = 1;
+
+function idbOpen() {
+    return new Promise((resolve, reject) => {
+        const req = indexedDB.open(IDB_NAME, IDB_VERSION);
+        req.onupgradeneeded = (e) => {
+            const db = e.target.result;
+            if (!db.objectStoreNames.contains(IDB_STORE)) {
+                db.createObjectStore(IDB_STORE);
+            }
+        };
+        req.onsuccess = (e) => resolve(e.target.result);
+        req.onerror   = (e) => reject(e.target.error);
+    });
+}
+
+// Populate /saves from IndexedDB before Python starts.
+// This runs entirely before runPythonAsync, so Atomics.wait is not yet active
+// and the event loop is free to process IDB callbacks normally.
+// Always resolves (never rejects) — a restore failure starts with empty saves.
+async function loadSavesFromIDB(pyodide) {
+    try {
+        const db = await Promise.race([
+            idbOpen(),
+            new Promise((_, rej) =>
+                setTimeout(() => rej(new Error('IDB open timeout')), 5000)
+            ),
+        ]);
+
+        const entries = await new Promise((resolve, reject) => {
+            const result  = [];
+            let tx, cursorReq;
+            try {
+                tx        = db.transaction(IDB_STORE, 'readonly');
+                cursorReq = tx.objectStore(IDB_STORE).openCursor();
+            } catch(e) { reject(e); return; }
+            cursorReq.onsuccess = (ev) => {
+                const c = ev.target.result;
+                if (c) { result.push({ path: c.key, content: c.value }); c.continue(); }
+                else   resolve(result);
+            };
+            cursorReq.onerror = () => reject(cursorReq.error);
+            tx.onerror        = () => reject(tx.error);
+            tx.onabort        = () => reject(new Error('IDB transaction aborted'));
+        });
+
+        let n = 0;
+        for (const { path, content } of entries) {
+            const parts = path.split('/').filter(Boolean);
+            let cur = '';
+            for (let i = 0; i < parts.length - 1; i++) {
+                cur += '/' + parts[i];
+                try { pyodide.FS.mkdir(cur); } catch {}
+            }
+            try {
+                if (content instanceof ArrayBuffer || ArrayBuffer.isView(content)) {
+                    pyodide.FS.writeFile(path, new Uint8Array(content));
+                } else {
+                    pyodide.FS.writeFile(path, content, { encoding: 'utf8' });
+                }
+                n++;
+            } catch(e) { console.warn('[roam] could not restore', path, e); }
+        }
+        if (n > 0) console.log(`[roam] ${n} save file(s) restored from IndexedDB`);
+        try { db.close(); } catch {}
+
+    } catch(err) {
+        console.warn('[roam] save restore skipped (non-fatal):', err);
+    }
+}
+
+// ── Save flush: Worker collects files and postMessages to main thread ─────────
+// syncSaves walks /saves synchronously (safe while Python is blocked because
+// pyodide.FS is pure JavaScript) and sends the file map to the main thread,
+// which writes to IDB from its own event loop. self.postMessage is synchronous
+// and does NOT require the Worker event loop to be running.
+
+function makeSyncSaves(pyodide) {
+    return () => {
+        const files = {};
+        function walk(path) {
+            let entries;
+            try { entries = pyodide.FS.readdir(path); } catch { return; }
+            for (const name of entries) {
+                if (name === '.' || name === '..') continue;
+                const full = `${path}/${name}`;
+                let stat;
+                try { stat = pyodide.FS.stat(full); } catch { continue; }
+                if ((stat.mode & 0o170000) === 0o040000) {
+                    walk(full);
+                } else {
+                    // Try UTF-8 (JSON saves); fall back to binary (map PNGs).
+                    try {
+                        files[full] = pyodide.FS.readFile(full, { encoding: 'utf8' });
+                    } catch {
+                        try {
+                            // ArrayBuffer is transferable — main thread can
+                            // receive and write it to IDB without copying.
+                            files[full] = pyodide.FS.readFile(full).buffer;
+                        } catch {}
+                    }
+                }
+            }
+        }
+        try { walk('/saves'); } catch {}
+        // postMessage is synchronous from the Worker's perspective; no event
+        // loop is needed.  The main thread queues and drains these on its own.
+        self.postMessage({ type: 'save', files });
+    };
+}
+
+// ── Worker entry point ────────────────────────────────────────────────────────
+
 self.onmessage = async (e) => {
     if (e.data.type !== 'init') return;
 
     const { sab } = e.data;
-    const sabMeta = new Int32Array(sab, 0, 2);        // [writeIdx, readIdx]
+    const sabMeta = new Int32Array(sab, 0, 2);
     const sabData = new Uint8Array(sab, 8, SAB_RING_SIZE);
 
-    // Expose SAB and helpers to Python via globalThis (accessible as js.* in Pyodide)
-    globalThis.sabMeta    = sabMeta;
-    globalThis.sabData    = sabData;
+    globalThis.sabMeta     = sabMeta;
+    globalThis.sabData     = sabData;
     globalThis.sabRingSize = SAB_RING_SIZE;
-    globalThis.sendToMain = (data) => self.postMessage(data);
+    globalThis.sendToMain  = (data) => self.postMessage(data);
 
     try {
         self.postMessage({ type: 'status', msg: 'Loading Python runtime…' });
@@ -36,43 +162,16 @@ self.onmessage = async (e) => {
             stderr: (msg) => console.warn('[roam]', msg),
         });
 
-        self.postMessage({ type: 'status', msg: 'Mounting save storage…' });
+        self.postMessage({ type: 'status', msg: 'Restoring saves…' });
 
-        // OPFS gives Python synchronous persistent file I/O without needing
-        // Emscripten's async IDBFS flush cycle — saves survive page reloads and
-        // are isolated per browser profile (no shared server filesystem).
-        //
-        // pyodide.mountNativeFS() returns { syncfs } — call syncfs() to flush
-        // Emscripten's in-memory cache to the actual OPFS backing store.
         pyodide.FS.mkdir('/saves');
-        let _nativeFSMount = null;
-        try {
-            const opfsRoot = await navigator.storage.getDirectory();
-            _nativeFSMount = await pyodide.mountNativeFS('/saves', opfsRoot);
-            console.log('[roam] OPFS mounted; saves will persist across reloads');
-        } catch(err) {
-            // OPFS not available in older browsers or non-secure contexts
-            console.warn('[roam] OPFS unavailable; saves will not persist:', err);
-        }
+        await loadSavesFromIDB(pyodide);  // runs before Python; IDB works here
 
-        // Expose syncSaves() to Python (accessible as js.syncSaves) so that
-        // after every write the in-memory FS is flushed to OPFS.
-        // Also called on a 3-second interval so saves persist even if the tab
-        // is closed between explicit sync points.
-        globalThis.syncSaves = () => {
-            if (_nativeFSMount && typeof _nativeFSMount.syncfs === 'function') {
-                _nativeFSMount.syncfs().catch(
-                    (err) => console.warn('[roam] syncfs failed:', err)
-                );
-            }
-        };
-        // Periodic flush — fires during Python's time.sleep() yields.
-        setInterval(syncSaves, 3000);
+        // Wire syncSaves AFTER pyodide is initialised.
+        globalThis.syncSaves = makeSyncSaves(pyodide);
 
         self.postMessage({ type: 'status', msg: 'Installing Python packages…' });
 
-        // Pillow and jsonschema are bundled with Pyodide; structlog comes from PyPI.
-        // micropip handles PyPI installs and skips packages already available.
         await pyodide.loadPackage(['Pillow', 'jsonschema', 'micropip']);
         const micropip = pyodide.pyimport('micropip');
         await micropip.install('structlog');
@@ -87,9 +186,6 @@ self.onmessage = async (e) => {
 
         self.postMessage({ type: 'status', msg: 'Starting game…' });
 
-        // Run the game — this blocks for the lifetime of the session.
-        // /game/web/ is added to sys.path so pyodide_main.py can import
-        // pyodide_compat (the synchronous ThreadPoolExecutor shim).
         await pyodide.runPythonAsync(`
 import sys, os
 sys.path.insert(0, '/game/src')

--- a/web/index.html
+++ b/web/index.html
@@ -456,6 +456,43 @@
     statusEl.classList.toggle('error', !!isError);
   }
 
+  // ── IndexedDB save persistence (main-thread side) ─────────────────────────
+  // The Worker can't write to IDB while Python runs (Atomics.wait blocks the
+  // Worker event loop). Instead, the Worker postMessages the file map and the
+  // main thread writes to IDB from its own unblocked event loop.
+
+  const _IDB_NAME    = 'roam-saves';
+  const _IDB_STORE   = 'files';
+  const _IDB_VERSION = 1;
+
+  function _idbOpen() {
+    return new Promise((resolve, reject) => {
+      const req = indexedDB.open(_IDB_NAME, _IDB_VERSION);
+      req.onupgradeneeded = (ev) => {
+        const db = ev.target.result;
+        if (!db.objectStoreNames.contains(_IDB_STORE)) {
+          db.createObjectStore(_IDB_STORE);
+        }
+      };
+      req.onsuccess = (ev) => resolve(ev.target.result);
+      req.onerror   = (ev) => reject(ev.target.error);
+    });
+  }
+
+  function _idbWrite(files) {
+    _idbOpen().then((db) => {
+      let tx;
+      try { tx = db.transaction(_IDB_STORE, 'readwrite'); }
+      catch(e) { console.warn('[roam] IDB write tx failed:', e); db.close(); return; }
+      try { tx.objectStore(_IDB_STORE).clear(); } catch {}
+      for (const [path, content] of Object.entries(files)) {
+        try { tx.objectStore(_IDB_STORE).put(content, path); } catch {}
+      }
+      tx.oncomplete = () => db.close();
+      tx.onerror    = () => { console.warn('[roam] IDB write error:', tx.error); db.close(); };
+    }).catch((err) => console.warn('[roam] IDB open failed:', err));
+  }
+
   function startWorker() {
     setStatus("Loading…");
     showBar();
@@ -474,6 +511,7 @@
       if (d.type === 'status') { setStatus(d.msg); return; }
       if (d.type === 'ready')  { return; }
       if (d.type === 'error')  { setStatus('Error: ' + d.msg, true); showBar(); }
+      if (d.type === 'save')   { _idbWrite(d.files); return; }
     };
     worker.postMessage({ type: 'init', sab });
   }


### PR DESCRIPTION
## Summary

Replaces PR #515 (which had unresolvable merge conflicts with main).

**Root cause**: Pyodide uses `Atomics.wait()` for `time.sleep()` when SharedArrayBuffer is available. This blocks the Web Worker's JS event loop entirely while Python runs — so IDB macrotask callbacks could never fire. Every previous approach (OPFS, IDBFS, `setInterval` flush, `await idbOpen()` in the Worker) silently hung without writing anything.

**Fix**: The Worker walks `/saves` synchronously via `pyodide.FS` (pure JS, safe while Python is blocked) and `postMessage`s `{ type: 'save', files }` to the main thread. The main thread writes to IDB from its own unblocked event loop. Save restore on startup is unchanged — it runs before `runPythonAsync`, so the Worker event loop is still free then.

## Also included

- `tests/integration/test_save_persistence.js`: Playwright e2e test — navigates the game, polls IDB, reloads, verifies files survive. Verified passing against https://roam.preponderous.org.
- `.github/workflows/integration.yml`: CI job that builds `game.zip`, starts `serve.py`, and runs the Playwright test on every push/PR.

## Test plan
- [x] Playwright integration test: PASS on prod (`codex.json`, `goals.json` persisted and restored)
- [x] 972 Python unit tests: all pass
- [x] black formatting: clean
- [ ] Manual verify: Ecosia on Pixel (game starts + saves survive refresh)

Closes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_