### PR TITLE
test: 7 new roamscripts covering menu nav, inventory, toggles, save load/rename

### DIFF
--- a/docs/roamscript.md
+++ b/docs/roamscript.md
@@ -42,6 +42,8 @@ would otherwise look like a `timeout=` token.
 | `assertContains TEXT [timeout=N]` | Like `expect`, but framed as an assertion with a short default timeout (`1.0`s) — use when `TEXT` should already be on screen. |
 | `assertNotContains TEXT [timeout=N]` | Fails if `TEXT` appears within `timeout` seconds (default `0.5`). |
 | `assertPathExists PATH` | Fails unless `PATH` (repo-relative) exists on disk. |
+| `assertPathNotExists PATH` | Fails if `PATH` (repo-relative) exists on disk. |
+| `resetBuffer` | Discard captured output so far. See "Re-visiting a screen" below — required before `expect`/`assertContains`/`assertNotContains` can prove anything about a screen you've already been on. |
 | `wait SECONDS` | Pace the script without asserting anything. Prefer `expect`/`assertContains` — they fail fast and name what they were waiting for; reach for `wait` only when there's genuinely nothing to match on. |
 
 Named `send` tokens:
@@ -65,6 +67,29 @@ A script never needs to assert a clean exit itself: `runScript()` always
 checks, after the last line, that the child process exited without dumping a
 traceback — mirroring the `assert game.cleanExit()` convention in
 `test_text_playthrough.py`.
+
+## Re-visiting a screen
+
+The captured output is a running transcript of everything the game has ever
+printed, not a live snapshot of the current screen — it only ever grows.
+That has two consequences:
+
+- `expect`/`assertContains` for text a screen already showed once will match
+  instantly from history the *next* time you visit that screen too, even if
+  the real render is broken or slow — a false-pass risk, not real evidence.
+- `assertNotContains` can only prove text *never appeared at all* in the
+  whole run. It can't prove a "was on screen, now isn't" transition, because
+  the earlier occurrence is still sitting in the transcript.
+
+Call `resetBuffer` right before the transition you actually want evidence
+for, so the following `expect`/`assertContains`/`assertNotContains` can only
+match genuinely new output:
+
+```
+send esc
+resetBuffer
+expect Tick timeout=10
+```
 
 ## Example
 

--- a/tests/integration/roamScript.py
+++ b/tests/integration/roamScript.py
@@ -21,12 +21,23 @@ from textPlaythrough import REPO_ROOT, TextPlaythrough
 #     assertContains TEXT [timeout=N]     TEXT must already be on screen
 #     assertNotContains TEXT [timeout=N]  TEXT must NOT appear within timeout
 #     assertPathExists PATH               a repo-relative path must exist
+#     assertPathNotExists PATH            a repo-relative path must NOT exist
+#     resetBuffer                         discard captured output so far
 #     wait SECONDS                        pace the script; asserts nothing
 #
 # `{saveName}` in any argument is replaced with the run's generated save
 # name. Quote an argument (`"like this"`) to keep spaces together as one
 # TEXT/PATH; unquoted words are joined with a single space. Lines starting
 # with `#` and blank lines are ignored.
+#
+# The captured output is a running transcript that only ever grows, not a
+# live screen snapshot — so once TEXT has appeared, `expect`/`assertContains`
+# match it forever, even long after navigating away. That makes a bare
+# `expect` a false-pass risk for "we're back on a screen we've already
+# visited" and makes `assertNotContains` unable to prove a "was on screen,
+# now isn't" transition. Use `resetBuffer` right before the transition you
+# actually want evidence for, so the following `expect`/`assertContains`/
+# `assertNotContains` can only match genuinely new output.
 #
 # A script never needs to ask for a clean-exit check: runScript() always
 # verifies the child exited without a traceback after the last line, mirroring
@@ -140,11 +151,26 @@ def _handleAssertPathExists(game, rest):
         raise AssertionError("path does not exist: %s" % fullPath)
 
 
+def _handleAssertPathNotExists(game, rest):
+    tokens = shlex.split(_substitute(rest, game))
+    if len(tokens) != 1:
+        raise RoamScriptError("assertPathNotExists takes exactly one path argument")
+    fullPath = os.path.join(REPO_ROOT, tokens[0])
+    if os.path.exists(fullPath):
+        raise AssertionError("path exists but was expected not to: %s" % fullPath)
+
+
 def _handleWait(game, rest):
     tokens = shlex.split(rest)
     if len(tokens) != 1:
         raise RoamScriptError("wait takes exactly one number of seconds")
     game.drain(float(tokens[0]))
+
+
+def _handleResetBuffer(game, rest):
+    if rest.strip():
+        raise RoamScriptError("resetBuffer takes no arguments")
+    game.resetBuffer()
 
 
 _HANDLERS = {
@@ -153,6 +179,8 @@ _HANDLERS = {
     "assertContains": _handleAssertContains,
     "assertNotContains": _handleAssertNotContains,
     "assertPathExists": _handleAssertPathExists,
+    "assertPathNotExists": _handleAssertPathNotExists,
+    "resetBuffer": _handleResetBuffer,
     "wait": _handleWait,
 }
 

--- a/tests/integration/scripts/load_existing_save_from_selection_screen.roamscript
+++ b/tests/integration/scripts/load_existing_save_from_selection_screen.roamscript
@@ -1,0 +1,31 @@
+# Loading an existing save (not creating a new one) reaches the ticking
+# world too — a path create_save_and_enter_world.roamscript never exercises.
+# Create {saveName}, back out to the main menu through the world's Options
+# menu (Esc -> Quit to Main Menu -> confirm), reopen save selection, and
+# press Enter on the now-listed save instead of 'c'.
+#
+# "Roam" and "Select Save" already appeared once during the initial boot
+# above, so resetBuffer runs right before the return-to-main-menu confirm —
+# without it, the re-`expect`s below would trivially match old history
+# instead of proving the main menu and save-selection screen actually
+# re-rendered after the round trip.
+expect Roam
+send enter
+expect Select Save
+send c
+expect Enter save name
+send {saveName} enter
+expect Tick timeout=15
+send esc
+expect Menu
+send enter
+expect Return to main menu?
+resetBuffer
+send enter
+expect Roam timeout=15
+send enter
+expect Select Save timeout=10
+assertContains {saveName}
+send enter
+expect Tick timeout=15
+assertContains TPS

--- a/tests/integration/scripts/open_and_close_inventory.roamscript
+++ b/tests/integration/scripts/open_and_close_inventory.roamscript
@@ -1,0 +1,35 @@
+# Opening the inventory from the world renders the panel and its close hint;
+# reopening after closing it proves the world screen is still alive and
+# responsive underneath (a round-trip, not just an open-once check) — the
+# risk case CLAUDE.md's frontend-abstraction note calls out, since
+# InventoryScreen is one of only two screens with explicit text/pygame
+# branching (self.renderer.supportsImageLoading()).
+#
+# resetBuffer before each close is what makes assertNotContains meaningful
+# here — without it, the close hint would still be sitting in the buffer's
+# history from having been on screen a moment ago, and assertNotContains
+# would fail every time regardless of whether the panel actually closed.
+#
+# The full nav-hint line (inventoryScreen.py:234) exists in source but the
+# text-mode grid overlaps it with the Craft button's border at this
+# viewport width, so it never appears as one contiguous substring in the
+# captured transcript — "discard held" is a short fragment confirmed to
+# land clear of the overlap.
+expect Roam
+send enter
+expect Select Save
+send c
+expect Enter save name
+send {saveName} enter
+expect Tick timeout=15
+send i
+assertContains "press [I] or [Esc] to close"
+assertContains "discard held"
+resetBuffer
+send esc
+assertNotContains "press [I] or [Esc] to close" timeout=1
+send i
+assertContains "press [I] or [Esc] to close"
+resetBuffer
+send esc
+assertNotContains "press [I] or [Esc] to close" timeout=1

--- a/tests/integration/scripts/options_menu_reaches_stats_inventory_controls_codex.roamscript
+++ b/tests/integration/scripts/options_menu_reaches_stats_inventory_controls_codex.roamscript
@@ -1,0 +1,89 @@
+# The world's Options menu (Esc) reaches Stats, Inventory, Controls, and
+# Codex. Stats/Controls/Codex return to the Options menu; Inventory returns
+# straight to the world. (Codex is the subtle one: CodexScreen tracks
+# whichever screen it was opened *from* and returns there -- roam.py's
+# screen-switch dispatcher calls setReturnScreen(OPTIONS_SCREEN) when
+# entering from Options, WORLD_SCREEN otherwise -- so it only returns
+# straight to the world if opened directly from the world, e.g. via 'L'.)
+# The script reopens the Options menu explicitly wherever that matters.
+# Assertions target content unique to each destination screen rather than
+# its name, since the Options menu itself displays every sub-screen's name
+# as a button label (so "Controls"/"Codex" alone would trivially match the
+# menu, not the screen).
+#
+# Every screen transition is followed by resetBuffer + a fresh `expect` for
+# that screen's own marker before sending further keys, for two reasons:
+# (1) OptionsScreen resets its cursor to 0 on every entry (onStart, called by
+# Screen.run() at the start of every visit) -- but keys sent immediately
+# after an `esc` can arrive before the new screen's event loop is actually
+# polling again and get silently dropped rather than misapplied (confirmed:
+# sending "down down enter" right after an unsynchronized `esc` landed on
+# "Quit to Main Menu" instead of Inventory, i.e. both downs were lost and the
+# cursor was still at 0). A resetBuffer + expect pair only returns once that
+# screen has genuinely rendered a frame -- real evidence the next keypress
+# will land where intended. (2) it also makes each `expect` real evidence
+# instead of a trivial match against a screen already visited earlier in
+# this same script.
+expect Roam
+send enter
+expect Select Save
+send c
+expect Enter save name
+send {saveName} enter
+expect Tick timeout=15
+
+# Options menu opens; cursor starts at index 0 (Quit to Main Menu).
+send esc
+expect Menu
+
+# Stats is index 1 -> one Down.
+send down
+send enter
+expect Statistics
+resetBuffer
+
+# Esc from Stats returns to the Options menu, cursor reset to 0.
+# Inventory is index 2 -> two Downs.
+send esc
+expect Menu timeout=10
+send down down
+send enter
+assertContains "or [Esc] to close" timeout=5
+resetBuffer
+
+# Esc from Inventory returns straight to the world, not the Options menu.
+send esc
+expect Tick timeout=10
+assertContains TPS
+resetBuffer
+
+# Reopen the menu (cursor resets to 0 again). Controls is index 3 -> three Downs.
+send esc
+expect Menu timeout=10
+send down down down
+send enter
+assertContains "Enter/Space: remap" timeout=5
+resetBuffer
+
+# Esc from Controls returns to the Options menu, cursor reset to 0.
+# Codex is index 4 -> four Downs.
+send esc
+expect Menu timeout=10
+send down down down down
+send enter
+assertContains discovered timeout=5
+resetBuffer
+
+# Esc from Codex returns to the Options menu -- not straight to the world
+# like Inventory. CodexScreen tracks whichever screen it was opened *from*
+# and returns there (roam.py's screen-switch dispatcher:
+# codexScreen.setReturnScreen(OPTIONS_SCREEN if opened from Options else
+# WORLD_SCREEN)); since this script always opens Codex via the Options menu,
+# its Esc goes back to Options.
+send esc
+expect Menu timeout=10
+
+# One more Esc actually leaves the Options menu for the world.
+send esc
+expect Tick timeout=10
+assertContains TPS

--- a/tests/integration/scripts/quit_to_main_menu_requires_confirmation.roamscript
+++ b/tests/integration/scripts/quit_to_main_menu_requires_confirmation.roamscript
@@ -1,0 +1,40 @@
+# "Quit to Main Menu" (the Options menu's first, default-selected item) is
+# gated behind a confirmation overlay (optionsScreen.drawMainMenuConfirmation):
+# Escape cancels (confirmingMainMenu -> False, staying on the Options screen
+# per optionsScreen.handleKeyDownEvent) while Enter confirms and actually
+# switches to MAIN_MENU_SCREEN.
+#
+# Round trip: open menu -> select Quit -> cancel with Esc (still in-game) ->
+# close the menu -> reopen it -> select Quit again -> confirm with Enter this
+# time -> actually land on the main menu. "Roam" already appeared once at
+# boot, so resetBuffer runs right before the real confirm so the final
+# `expect Roam` is genuine fresh evidence the cancel path didn't quit early
+# and the confirm path did land back on the main menu, not a trivial match
+# against the initial boot text. assertPathExists is the other line of
+# evidence: the save created before quitting must still be there.
+expect Roam
+send enter
+expect Select Save
+send c
+expect Enter save name
+send {saveName} enter
+expect Tick timeout=15
+send esc
+expect Quit to Main Menu
+send enter
+expect Return to main menu?
+assertContains Your current session will end.
+assertContains Quit to Menu
+assertContains Cancel
+send esc
+wait 1
+send esc
+wait 1
+send esc
+wait 1
+send enter
+wait 1
+resetBuffer
+send enter
+expect Roam timeout=15
+assertPathExists saves/{saveName}

--- a/tests/integration/scripts/rename_save_from_selection_screen.roamscript
+++ b/tests/integration/scripts/rename_save_from_selection_screen.roamscript
@@ -1,0 +1,34 @@
+# Renaming an existing save via 'R' actually renames the save folder on
+# disk (SaveSelectionScreen.confirmRenameSave calls os.rename), not just a
+# display label. Create {saveName}, back out to save selection, press R on
+# the highlighted (only) save to open the rename dialog — pre-filled with
+# the current name — append "_renamed" and confirm.
+#
+# "Roam" and "Select Save" already appeared once during the initial boot
+# above, so resetBuffer runs right before the return-to-main-menu confirm —
+# without it, the re-`expect`s below would trivially match old history
+# instead of proving the main menu and save-selection screen actually
+# re-rendered after the round trip.
+expect Roam
+send enter
+expect Select Save
+send c
+expect Enter save name
+send {saveName} enter
+expect Tick timeout=15
+send esc
+expect Menu
+send enter
+expect Return to main menu?
+resetBuffer
+send enter
+expect Roam timeout=15
+send enter
+expect Select Save timeout=10
+assertContains {saveName}
+send r
+expect Rename save:
+send _renamed enter
+assertContains {saveName}_renamed
+assertPathExists saves/{saveName}_renamed
+assertPathNotExists saves/{saveName}

--- a/tests/integration/scripts/toggle_debug_and_help_overlays.roamscript
+++ b/tests/integration/scripts/toggle_debug_and_help_overlays.roamscript
@@ -1,0 +1,30 @@
+# Debug and help overlays both have a working ASCII alt binding, per
+# CLAUDE.md's "every terminal action needs an alt binding" rule:
+# toggle_debug is F3 (alt \) and toggle_help is F1 (alt h) — see
+# src/config/keyBindings.py. The repo's tracked config.yml ships
+# `debug: true`, so debug starts ON; the first \ turns it OFF, the second
+# turns it back ON. Each direction sets a distinct, brand-new status message
+# (worldScreen.py's handleKeyDownEvent) — that's what's asserted here rather
+# than presence/absence of the debug HUD text itself, since
+# TextPlaythrough's output buffer only ever grows (see
+# open_and_close_inventory.roamscript's note): a status message that is
+# genuinely new at the moment of the toggle is the one thing that's safe to
+# assertContains regardless of which direction the toggle went.
+#
+# Letter keys must be sent lowercase — KeyCode values for letters are their
+# lowercase ASCII ordinals (e.g. KeyCode.H = 104 = ord('h')), not the
+# uppercase letter shown in the UI/README.
+expect Roam
+send enter
+expect Select Save
+send c
+expect Enter save name
+send {saveName} enter
+expect Tick timeout=15
+send '\'
+assertContains "Debug info OFF"
+send '\'
+assertContains "Debug info ON"
+send h
+assertContains "Controls  (H to close)"
+send h

--- a/tests/integration/scripts/world_menu_opens_and_closes.roamscript
+++ b/tests/integration/scripts/world_menu_opens_and_closes.roamscript
@@ -1,0 +1,28 @@
+# Esc opens the in-world Options menu (optionsScreen.drawTitle() renders
+# "Menu", with "Quit to Main Menu" as the first, default-selected item); Esc
+# again closes it and returns to the world (optionsScreen.handleKeyDownEvent:
+# ESCAPE while not confirming -> switchToWorldScreen()).
+#
+# "Tick"/"TPS" already appeared once from the create-save lead-in below, so
+# re-`expect`ing them after closing the menu would trivially pass from
+# history without proving the world screen actually came back — resetBuffer
+# clears that history first so the final expect is genuine fresh evidence.
+expect Roam
+send enter
+expect Select Save
+send c
+expect Enter save name
+send {saveName} enter
+expect Tick timeout=15
+assertContains TPS
+send esc
+expect Quit to Main Menu
+assertContains Stats
+assertContains Inventory
+assertContains Controls
+assertContains Codex
+assertContains Back
+resetBuffer
+send esc
+expect Tick timeout=10
+assertContains TPS

--- a/tests/integration/textPlaythrough.py
+++ b/tests/integration/textPlaythrough.py
@@ -92,10 +92,19 @@ class TextPlaythrough:
         return False
 
     def _cleanupSave(self):
+        import glob
         import shutil
 
-        savePath = os.path.join(REPO_ROOT, "saves", self._saveName)
-        shutil.rmtree(savePath, ignore_errors=True)
+        # A prefix glob, not just an exact match on self._saveName: a script
+        # that renames the save mid-run (SaveSelectionScreen's rename dialog
+        # does a real os.rename) leaves the original name gone and a new one
+        # behind that this class was never told about. self._saveName is
+        # always a freshly generated, effectively-unique token, so matching
+        # anything starting with it can't catch a real user save.
+        for savePath in glob.glob(
+            os.path.join(REPO_ROOT, "saves", self._saveName + "*")
+        ):
+            shutil.rmtree(savePath, ignore_errors=True)
 
     # --- driving ---
 
@@ -139,6 +148,15 @@ class TextPlaythrough:
     def drain(self, seconds=0.5):
         self._pump(seconds)
         return self._buffer
+
+    def resetBuffer(self):
+        """Discard everything captured so far. The buffer only ever grows
+        (it's a running transcript, not a live screen snapshot), so text a
+        screen showed once keeps matching `expect`/`assertContains` forever
+        even after navigating away — resetting it is what makes "we left
+        that screen" or "this went from on to off" provable rather than
+        assumed."""
+        self._buffer = ""
 
     # --- inspection ---
 


### PR DESCRIPTION
## Summary
- Extends RoamScript coverage (#528) past "the world renders" into the actual gameplay UI: the in-world Options menu and its quit-confirmation gate, its 4 sub-screens (Stats/Inventory/Controls/Codex), the inventory open/close round trip, the debug/help ASCII alt-key toggles, and loading + renaming an existing save.
- Fixes two real interpreter gaps found while verifying these against the real running game: the captured output buffer only ever grows (so re-visiting a screen could trivially "pass" from history, and toggle-off could never be proven) — added `resetBuffer` and `assertPathNotExists`. Also fixed save cleanup to prefix-glob the generated save name, since a mid-run rename left the renamed directory behind forever.
- All 7 new scripts plus the original 4 were run end-to-end against the actual game process (not just parse-validated) and pass.

## Test plan
- [x] `python3 -m black --check tests/integration/roamScript.py tests/integration/textPlaythrough.py`
- [x] All 11 `.roamscript` files parse cleanly
- [x] Each of the 7 new scripts run individually via `tests/integration/roamScript.py --boot-timeout=N` against the real game — PASS
- [x] Re-ran all 4 pre-existing scripts to confirm no regression from the `resetBuffer`/cleanup changes — PASS
- [x] Confirmed no leftover save directories after a rename-script run (previously left an orphaned `*_renamed` folder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_